### PR TITLE
Add extension pubkey

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,5 +1,6 @@
 {
     "manifest_version": 3,
+    "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAoasM13FWg9dB6ufOs6gHQKfExEmQkaXR7uVMRtJPvmLQB8EnivUNLGQ0b8OZ5Eggn21oXNgdEl7WhcKLuK20cHcW61TE7XAKIcV6uDmlc1FJFczxpqI7L+GgeeAtiC9vkHFulBHmfCxq4z8+zqNRLpwZ6xMyt6j9rJ7V1h7Uv0n4shf6xG0ukyTpfAc64Pkp4GtG+bdy51ki9XE0pJEnyotk5I9eGKp/3kL0EAQW0a9ES/5LM+fFwPU2EWZlqkx07zd1AnlzzQ4kz2rceBUIkI/x1mPyzNkPlnOtvlNUooFq8J5L3be2n1pZS099OM5ZLKKjomARcr/iiqgrjdkXAQIDAQAB",
     "name": "mirrord",
     "version": "0.1",
     "description": "More user-friendly testing with mirrord by automatically injecting HTTP header",


### PR DESCRIPTION
Chrome Web Store generates private public key pair for signing extension for publishing. Once our extension is published, Google shares with us the public key. The extension ID is derived from this public key. By putting the key in our package manifest, our extension ID remain the same even when it is loaded into Chrome in dev mode.