### PR TITLE
Add auto-reviewer assignment to ReviewPal workflow

### DIFF
--- a/.github/workflows/reviewpal.yml
+++ b/.github/workflows/reviewpal.yml
@@ -23,6 +23,19 @@ jobs:
               with:
                   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
+    auto-reviewers:
+        runs-on: ubuntu-latest
+        if: github.event_name == 'pull_request' && github.event.action == 'opened'
+        permissions:
+            contents: read
+            pull-requests: write
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+
+            - uses: metalbear-co/reviewpal/auto-reviewers@v2
+
     reply:
         runs-on: ubuntu-latest
         if: |


### PR DESCRIPTION
## Summary
- Adds auto-reviewers job to the ReviewPal workflow
- Automatically requests PR reviewers based on git history of changed files
- Uses the reusable `metalbear-co/reviewpal/auto-reviewers@v2` action

## Test plan
- [ ] Auto-reviewers job triggers on PR open and requests appropriate reviewers

🤖 Generated with [Claude Code](https://claude.com/claude-code)