### PR TITLE
Add PostHog analytics via direct API (no SDK)

### DIFF
--- a/e2e/analytics.spec.ts
+++ b/e2e/analytics.spec.ts
@@ -1,0 +1,112 @@
+import { test, expect } from './fixtures';
+import { addHeader } from './helpers';
+import type { BrowserContext, Page } from '@playwright/test';
+
+/**
+ * Instrument a page to capture analytics events by wrapping fetch().
+ *
+ * The analytics module sends events via fetch() to hog.metalbear.com/capture/.
+ * We intercept those calls with addInitScript to record the event payloads
+ * before they hit the network.
+ */
+async function setupAnalyticsSpy(page: Page): Promise<void> {
+    await page.addInitScript(() => {
+        (window as any).__captured_analytics__ = [];
+        const captured: Array<{ event: string; properties: any }> = (
+            window as any
+        ).__captured_analytics__;
+
+        const origFetch = window.fetch.bind(window);
+        window.fetch = async (input: any, init?: any) => {
+            try {
+                const url =
+                    typeof input === 'string' ? input : input?.url || '';
+                if (url.includes('/capture/') && init?.body) {
+                    const body = JSON.parse(init.body as string);
+                    captured.push({
+                        event: body.event,
+                        properties: body.properties || {},
+                    });
+                }
+            } catch {
+                // Don't break anything
+            }
+            return origFetch(input, init);
+        };
+
+        const origBeacon = navigator.sendBeacon.bind(navigator);
+        navigator.sendBeacon = (url: string, data?: any) => {
+            try {
+                if (url.includes('/capture/') && data) {
+                    const body = JSON.parse(data as string);
+                    captured.push({
+                        event: body.event,
+                        properties: body.properties || {},
+                    });
+                }
+            } catch {
+                // Don't break anything
+            }
+            return origBeacon(url, data);
+        };
+    });
+}
+
+async function getCapturedEvents(page: Page): Promise<string[]> {
+    return page.evaluate(() => {
+        const events: Array<{ event: string }> =
+            (window as any).__captured_analytics__ || [];
+        return events.map((e) => e.event);
+    });
+}
+
+async function openPopupWithSpy(
+    context: BrowserContext,
+    extensionId: string
+): Promise<Page> {
+    const page = await context.newPage();
+    await setupAnalyticsSpy(page);
+    await page.goto(`chrome-extension://${extensionId}/pages/popup.html`);
+    return page;
+}
+
+test.describe('Analytics events', () => {
+    test('popup open sends extension_popup_opened event', async ({
+        context,
+        extensionId,
+    }) => {
+        const page = await openPopupWithSpy(context, extensionId);
+        await expect(page.getByText('mirrord')).toBeVisible();
+
+        const events = await getCapturedEvents(page);
+        expect(events).toContain('extension_popup_opened');
+    });
+
+    test('saving a header rule sends extension_header_rule_saved event', async ({
+        context,
+        extensionId,
+    }) => {
+        const page = await openPopupWithSpy(context, extensionId);
+        await expect(page.getByText('Inactive')).toBeVisible();
+
+        await addHeader(page, 'X-Analytics-Test', 'analytics-value');
+
+        const events = await getCapturedEvents(page);
+        expect(events).toContain('extension_header_rule_saved');
+    });
+
+    test('removing a header rule sends extension_header_rule_removed event', async ({
+        context,
+        extensionId,
+    }) => {
+        const page = await openPopupWithSpy(context, extensionId);
+        await expect(page.getByText('Inactive')).toBeVisible();
+
+        await addHeader(page, 'X-Remove-Analytics', 'remove-me');
+        await page.getByRole('button', { name: 'Remove' }).click();
+        await expect(page.getByText('Inactive')).toBeVisible();
+
+        const events = await getCapturedEvents(page);
+        expect(events).toContain('extension_header_rule_removed');
+    });
+});

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,0 +1,20 @@
+import type { Page } from '@playwright/test';
+import { expect } from './fixtures';
+
+/**
+ * Fill and save a header rule via the popup UI.
+ */
+export async function addHeader(
+    popupPage: Page,
+    headerName: string,
+    headerValue: string,
+    scope?: string
+) {
+    await popupPage.locator('#headerName').fill(headerName);
+    await popupPage.locator('#headerValue').fill(headerValue);
+    if (scope) {
+        await popupPage.locator('#scope').fill(scope);
+    }
+    await popupPage.getByRole('button', { name: 'Save' }).click();
+    await expect(popupPage.getByText('Saved!')).toBeVisible();
+}

--- a/src/__tests__/analytics.test.ts
+++ b/src/__tests__/analytics.test.ts
@@ -1,0 +1,120 @@
+const mockFetch = jest.fn().mockResolvedValue({});
+const mockSendBeacon = jest.fn().mockReturnValue(true);
+
+Object.defineProperty(globalThis, 'fetch', {
+    value: mockFetch,
+    writable: true,
+});
+Object.defineProperty(navigator, 'sendBeacon', {
+    value: mockSendBeacon,
+    writable: true,
+});
+
+// Mock crypto.randomUUID
+Object.defineProperty(globalThis.crypto, 'randomUUID', {
+    value: jest.fn().mockReturnValue('test-uuid-1234'),
+    writable: true,
+});
+
+// Mock localStorage
+const store: Record<string, string> = {};
+const mockLocalStorage = {
+    getItem: jest.fn((key: string) => store[key] ?? null),
+    setItem: jest.fn((key: string, value: string) => {
+        store[key] = value;
+    }),
+    removeItem: jest.fn((key: string) => {
+        delete store[key];
+    }),
+    clear: jest.fn(() => {
+        for (const key of Object.keys(store)) delete store[key];
+    }),
+    length: 0,
+    key: jest.fn(),
+};
+Object.defineProperty(globalThis, 'localStorage', {
+    value: mockLocalStorage,
+    writable: true,
+});
+
+import { capture, captureBeacon } from '../analytics';
+
+describe('analytics', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockLocalStorage.clear();
+    });
+
+    describe('capture', () => {
+        it('sends event via fetch to PostHog capture endpoint', () => {
+            capture('test_event');
+
+            expect(mockFetch).toHaveBeenCalledWith(
+                'https://hog.metalbear.com/capture/',
+                expect.objectContaining({
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                })
+            );
+
+            const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+            expect(body.api_key).toBe(
+                'phc_wIZh92nyk4vu6HidiLFUzjW6piZlZszuWZZFBS7yHHe'
+            );
+            expect(body.event).toBe('test_event');
+            expect(body.distinct_id).toBeTruthy();
+            expect(body.properties.$lib).toBe('mirrord-browser-extension');
+            expect(body.timestamp).toBeTruthy();
+        });
+
+        it('includes custom properties', () => {
+            capture('test_event', { action: 'save', count: 5 });
+
+            const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+            expect(body.properties.action).toBe('save');
+            expect(body.properties.count).toBe(5);
+            expect(body.properties.$lib).toBe('mirrord-browser-extension');
+        });
+
+        it('does not throw when fetch fails', () => {
+            mockFetch.mockRejectedValueOnce(new Error('network error'));
+            expect(() => capture('test_event')).not.toThrow();
+        });
+    });
+
+    describe('captureBeacon', () => {
+        it('sends event via sendBeacon', () => {
+            captureBeacon('close_event', { duration_ms: 500 });
+
+            expect(mockSendBeacon).toHaveBeenCalledWith(
+                'https://hog.metalbear.com/capture/',
+                expect.any(String)
+            );
+
+            const payload = JSON.parse(mockSendBeacon.mock.calls[0][1]);
+            expect(payload.event).toBe('close_event');
+            expect(payload.properties.duration_ms).toBe(500);
+            expect(payload.properties.$lib).toBe('mirrord-browser-extension');
+        });
+
+        it('does not throw when sendBeacon fails', () => {
+            mockSendBeacon.mockImplementationOnce(() => {
+                throw new Error('beacon error');
+            });
+            expect(() => captureBeacon('test_event')).not.toThrow();
+        });
+    });
+
+    describe('distinct ID', () => {
+        it('uses consistent distinct ID across events', () => {
+            capture('event1');
+            const body1 = JSON.parse(mockFetch.mock.calls[0][1].body);
+
+            capture('event2');
+            const body2 = JSON.parse(mockFetch.mock.calls[1][1].body);
+
+            expect(body1.distinct_id).toBeTruthy();
+            expect(body1.distinct_id).toBe(body2.distinct_id);
+        });
+    });
+});

--- a/src/__tests__/popup.test.tsx
+++ b/src/__tests__/popup.test.tsx
@@ -2,6 +2,12 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import React from 'react';
 
+// Mock analytics module (must be before popup import since it fires at module level)
+jest.mock('../analytics', () => ({
+    capture: jest.fn(),
+    captureBeacon: jest.fn(),
+}));
+
 // Mock @metalbear/ui components to avoid ts-jest type resolution issues with VariantProps
 jest.mock('@metalbear/ui', () => ({
     Badge: ({

--- a/src/__tests__/useHeaderRules.test.ts
+++ b/src/__tests__/useHeaderRules.test.ts
@@ -1,0 +1,307 @@
+import { renderHook, act } from '@testing-library/react';
+
+// Mock analytics module
+const mockCapture = jest.fn();
+jest.mock('../analytics', () => ({
+    capture: (...args: unknown[]) => mockCapture(...args),
+}));
+
+// Mock chrome API
+const mockGetDynamicRules = jest.fn();
+const mockUpdateDynamicRules = jest.fn();
+const mockSetBadgeText = jest.fn();
+const mockSetBadgeTextColor = jest.fn();
+const mockStorageGet = jest.fn();
+const mockStorageSet = jest.fn();
+const mockStorageRemove = jest.fn();
+
+globalThis.chrome = {
+    declarativeNetRequest: {
+        getDynamicRules: mockGetDynamicRules,
+        updateDynamicRules: mockUpdateDynamicRules,
+        RuleActionType: {
+            MODIFY_HEADERS: 'modifyHeaders',
+        },
+        HeaderOperation: {
+            SET: 'set',
+        },
+    },
+    action: {
+        setBadgeText: mockSetBadgeText,
+        setBadgeTextColor: mockSetBadgeTextColor,
+    },
+    runtime: {
+        lastError: null,
+    },
+    storage: {
+        local: {
+            get: mockStorageGet,
+            set: mockStorageSet,
+            remove: mockStorageRemove,
+        },
+    },
+} as unknown as typeof chrome;
+
+import { useHeaderRules } from '../hooks/useHeaderRules';
+
+describe('useHeaderRules analytics', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        (
+            chrome.runtime as { lastError: chrome.runtime.LastError | null }
+        ).lastError = null;
+        mockGetDynamicRules.mockImplementation((cb) => cb([]));
+        mockStorageGet.mockImplementation((_keys, cb) => cb({}));
+    });
+
+    describe('handleRemove', () => {
+        it('captures extension_header_rule_removed on success', () => {
+            mockUpdateDynamicRules.mockImplementation((_opts, cb) => cb());
+            const { result } = renderHook(() => useHeaderRules());
+
+            act(() => {
+                result.current.handleRemove(1);
+            });
+
+            expect(mockCapture).toHaveBeenCalledWith(
+                'extension_header_rule_removed'
+            );
+        });
+
+        it('captures extension_error on failure', () => {
+            mockUpdateDynamicRules.mockImplementation((_opts, cb) => {
+                (
+                    chrome.runtime as {
+                        lastError: chrome.runtime.LastError | null;
+                    }
+                ).lastError = { message: 'remove failed' };
+                cb();
+                (
+                    chrome.runtime as {
+                        lastError: chrome.runtime.LastError | null;
+                    }
+                ).lastError = null;
+            });
+            const { result } = renderHook(() => useHeaderRules());
+
+            act(() => {
+                result.current.handleRemove(1);
+            });
+
+            expect(mockCapture).toHaveBeenCalledWith('extension_error', {
+                action: 'remove',
+                error: 'remove failed',
+            });
+        });
+    });
+
+    describe('handleSave', () => {
+        it('captures extension_header_rule_saved on success', async () => {
+            mockUpdateDynamicRules.mockImplementation((_opts, cb) => cb());
+            mockStorageSet.mockImplementation((_data, cb) => cb());
+            const { result } = renderHook(() => useHeaderRules());
+
+            act(() => {
+                result.current.setHeaderName('X-Test');
+                result.current.setHeaderValue('value');
+            });
+
+            await act(async () => {
+                result.current.handleSave();
+            });
+
+            expect(mockCapture).toHaveBeenCalledWith(
+                'extension_header_rule_saved',
+                { has_scope: false }
+            );
+        });
+
+        it('captures extension_header_rule_saved with scope', async () => {
+            mockUpdateDynamicRules.mockImplementation((_opts, cb) => cb());
+            mockStorageSet.mockImplementation((_data, cb) => cb());
+            const { result } = renderHook(() => useHeaderRules());
+
+            act(() => {
+                result.current.setHeaderName('X-Test');
+                result.current.setHeaderValue('value');
+                result.current.setScope('*://example.com/*');
+            });
+
+            await act(async () => {
+                result.current.handleSave();
+            });
+
+            expect(mockCapture).toHaveBeenCalledWith(
+                'extension_header_rule_saved',
+                { has_scope: true }
+            );
+        });
+
+        it('captures extension_error on update_rules failure', async () => {
+            mockUpdateDynamicRules.mockImplementation((_opts, cb) => {
+                (
+                    chrome.runtime as {
+                        lastError: chrome.runtime.LastError | null;
+                    }
+                ).lastError = { message: 'update failed' };
+                cb();
+                (
+                    chrome.runtime as {
+                        lastError: chrome.runtime.LastError | null;
+                    }
+                ).lastError = null;
+            });
+            jest.spyOn(window, 'alert').mockImplementation();
+            const { result } = renderHook(() => useHeaderRules());
+
+            act(() => {
+                result.current.setHeaderName('X-Test');
+                result.current.setHeaderValue('value');
+            });
+
+            await act(async () => {
+                result.current.handleSave();
+            });
+
+            expect(mockCapture).toHaveBeenCalledWith('extension_error', {
+                action: 'save',
+                step: 'update_rules',
+                error: 'update failed',
+            });
+        });
+
+        it('captures extension_error on storage_write failure', async () => {
+            mockUpdateDynamicRules.mockImplementation((_opts, cb) => cb());
+            mockStorageSet.mockImplementation((_data, cb) => {
+                (
+                    chrome.runtime as {
+                        lastError: chrome.runtime.LastError | null;
+                    }
+                ).lastError = { message: 'storage failed' };
+                cb();
+                (
+                    chrome.runtime as {
+                        lastError: chrome.runtime.LastError | null;
+                    }
+                ).lastError = null;
+            });
+            jest.spyOn(window, 'alert').mockImplementation();
+            const { result } = renderHook(() => useHeaderRules());
+
+            act(() => {
+                result.current.setHeaderName('X-Test');
+                result.current.setHeaderValue('value');
+            });
+
+            await act(async () => {
+                result.current.handleSave();
+            });
+
+            expect(mockCapture).toHaveBeenCalledWith('extension_error', {
+                action: 'save',
+                step: 'storage_write',
+                error: 'storage failed',
+            });
+        });
+    });
+
+    describe('handleReset', () => {
+        it('captures extension_header_rule_reset on success', () => {
+            mockStorageGet.mockImplementation((_keys, cb) =>
+                cb({
+                    defaults: {
+                        headerName: 'X-Default',
+                        headerValue: 'defaultval',
+                    },
+                })
+            );
+            mockStorageRemove.mockImplementation((_keys, cb) => cb());
+            mockUpdateDynamicRules.mockImplementation((_opts, cb) => cb());
+
+            const { result } = renderHook(() => useHeaderRules());
+
+            act(() => {
+                result.current.handleReset();
+            });
+
+            expect(mockCapture).toHaveBeenCalledWith(
+                'extension_header_rule_reset'
+            );
+        });
+
+        it('captures extension_error on storage_remove failure', () => {
+            mockStorageGet.mockImplementation((_keys, cb) =>
+                cb({
+                    defaults: {
+                        headerName: 'X-Default',
+                        headerValue: 'defaultval',
+                    },
+                })
+            );
+            mockStorageRemove.mockImplementation((_keys, cb) => {
+                (
+                    chrome.runtime as {
+                        lastError: chrome.runtime.LastError | null;
+                    }
+                ).lastError = { message: 'remove failed' };
+                cb();
+                (
+                    chrome.runtime as {
+                        lastError: chrome.runtime.LastError | null;
+                    }
+                ).lastError = null;
+            });
+            jest.spyOn(window, 'alert').mockImplementation();
+
+            const { result } = renderHook(() => useHeaderRules());
+
+            act(() => {
+                result.current.handleReset();
+            });
+
+            expect(mockCapture).toHaveBeenCalledWith('extension_error', {
+                action: 'reset',
+                step: 'storage_remove',
+                error: 'remove failed',
+            });
+        });
+
+        it('captures extension_error on update_rules failure', () => {
+            mockStorageGet.mockImplementation((_keys, cb) =>
+                cb({
+                    defaults: {
+                        headerName: 'X-Default',
+                        headerValue: 'defaultval',
+                    },
+                })
+            );
+            mockStorageRemove.mockImplementation((_keys, cb) => cb());
+            mockUpdateDynamicRules.mockImplementation((_opts, cb) => {
+                (
+                    chrome.runtime as {
+                        lastError: chrome.runtime.LastError | null;
+                    }
+                ).lastError = { message: 'update failed' };
+                cb();
+                (
+                    chrome.runtime as {
+                        lastError: chrome.runtime.LastError | null;
+                    }
+                ).lastError = null;
+            });
+            jest.spyOn(window, 'alert').mockImplementation();
+
+            const { result } = renderHook(() => useHeaderRules());
+
+            act(() => {
+                result.current.handleReset();
+            });
+
+            expect(mockCapture).toHaveBeenCalledWith('extension_error', {
+                action: 'reset',
+                step: 'update_rules',
+                error: 'update failed',
+            });
+        });
+    });
+});

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -1,0 +1,64 @@
+const POSTHOG_KEY = 'phc_wIZh92nyk4vu6HidiLFUzjW6piZlZszuWZZFBS7yHHe';
+const POSTHOG_HOST = 'https://hog.metalbear.com';
+
+let distinctId: string | null = null;
+
+function getDistinctId(): string {
+    if (distinctId) return distinctId;
+    const stored = localStorage.getItem('posthog_distinct_id');
+    if (stored) {
+        distinctId = stored;
+        return distinctId;
+    }
+    distinctId = crypto.randomUUID();
+    localStorage.setItem('posthog_distinct_id', distinctId);
+    return distinctId;
+}
+
+export function capture(
+    event: string,
+    properties?: Record<string, unknown>
+): void {
+    try {
+        fetch(`${POSTHOG_HOST}/capture/`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                api_key: POSTHOG_KEY,
+                event,
+                distinct_id: getDistinctId(),
+                properties: {
+                    ...properties,
+                    $lib: 'mirrord-browser-extension',
+                },
+                timestamp: new Date().toISOString(),
+            }),
+        }).catch(() => {});
+    } catch {
+        // Analytics should never break the extension
+    }
+}
+
+/**
+ * Send an event using navigator.sendBeacon (for popup close where fetch gets cancelled).
+ */
+export function captureBeacon(
+    event: string,
+    properties?: Record<string, unknown>
+): void {
+    try {
+        const payload = JSON.stringify({
+            api_key: POSTHOG_KEY,
+            event,
+            distinct_id: getDistinctId(),
+            properties: {
+                ...properties,
+                $lib: 'mirrord-browser-extension',
+            },
+            timestamp: new Date().toISOString(),
+        });
+        navigator.sendBeacon(`${POSTHOG_HOST}/capture/`, payload);
+    } catch {
+        // Analytics should never break the extension
+    }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,7 @@ import {
     STORAGE_KEYS,
     ALL_RESOURCE_TYPES,
 } from './types';
+import { capture } from './analytics';
 
 /**
  * Check if the input string is a regex or an explicit HTTP header.
@@ -219,6 +220,10 @@ document.addEventListener('DOMContentLoaded', async () => {
     try {
         await setHeaderRule(header, scope);
         const scopeMsg = scope ? ` (scope: ${scope})` : ' (all URLs)';
+        capture('extension_config_received', {
+            is_regex: isRegex(config.header_filter),
+            has_scope: !!scope,
+        });
         alert('Header set successfully!' + scopeMsg);
     } catch (err) {
         alert('Failed to set header: ' + (err as Error).message);

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -17,6 +17,21 @@ import {
 import { RulesList, HeaderForm } from './components';
 import { useHeaderRules } from './hooks';
 import { STRINGS } from './constants';
+import { capture, captureBeacon } from './analytics';
+
+// Fire popup_opened before React renders.
+// Extension popups can close before useEffect runs, so this must happen at module level.
+const popupOpenedAt = Date.now();
+capture('extension_popup_opened');
+
+// Track popup close with duration. Extension popups get destroyed immediately,
+// so use sendBeacon — it's the only reliable way to get a request out during teardown.
+document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState !== 'hidden') return;
+    captureBeacon('extension_popup_closed', {
+        duration_ms: Date.now() - popupOpenedAt,
+    });
+});
 
 export function Popup() {
     const {


### PR DESCRIPTION
## Summary

- Re-adds PostHog analytics that was reverted in #35, but using direct `fetch`/`sendBeacon` calls to PostHog's `/capture/` API instead of the `posthog-js` SDK
- The `posthog-js` SDK bundles `document.createElement("script")` internally which triggers Chrome Web Store's static analysis for remotely hosted code — this approach avoids that entirely
- Same events tracked as before: popup open/close, header rule save/remove/reset, config received, and error events
- Analytics failures are silently caught so they never break extension functionality
- No new dependencies added

**Stacked on #35** (revert PR)

## What changed

| File | Change |
|------|--------|
| `src/analytics.ts` | New module with `capture()` (fetch) and `captureBeacon()` (sendBeacon) |
| `src/popup.tsx` | Module-level popup open tracking + visibilitychange close tracking |
| `src/hooks/useHeaderRules.ts` | Analytics events for rule save/remove/reset/errors |
| `src/config.ts` | Analytics event for CLI config received |
| `src/__tests__/analytics.test.ts` | Unit tests for analytics module |
| `src/__tests__/useHeaderRules.test.ts` | Tests verifying all analytics events fire correctly |
| `src/__tests__/popup.test.tsx` | Updated to mock analytics module |

## Test plan

- [x] `pnpm build` — builds successfully, analytics bundle is 1.67 KB (vs ~400KB+ with posthog-js)
- [x] `pnpm test` — all 81 tests pass
- [x] Verified no `createElement("script")` in analytics bundle
- [x] Analytics bundle contains only fetch/sendBeacon calls
- [ ] Verify events appear in PostHog after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)