### PR TITLE
Fix E2E tests for redesigned popup UI

### DIFF
--- a/e2e/analytics.spec.ts
+++ b/e2e/analytics.spec.ts
@@ -103,7 +103,7 @@ test.describe('Analytics events', () => {
         await expect(page.getByText('Inactive')).toBeVisible();
 
         await addHeader(page, 'X-Remove-Analytics', 'remove-me');
-        await page.getByRole('button', { name: 'Remove' }).click();
+        await page.getByLabel('Toggle header injection').click();
         await expect(page.getByText('Inactive')).toBeVisible();
 
         const events = await getCapturedEvents(page);

--- a/e2e/extension.spec.ts
+++ b/e2e/extension.spec.ts
@@ -23,7 +23,6 @@ test.describe('mirrord browser extension', () => {
         popupPage,
     }) => {
         await expect(popupPage.getByText('Inactive')).toBeVisible();
-        await expect(popupPage.getByText('No active headers')).toBeVisible();
     });
 
     test('add a header and verify it appears in popup', async ({
@@ -90,11 +89,10 @@ test.describe('mirrord browser extension', () => {
             popupPage.getByText('Active', { exact: true })
         ).toBeVisible();
 
-        // Remove it
-        await popupPage.getByRole('button', { name: 'Remove' }).click();
+        // Toggle off to remove
+        await popupPage.getByLabel('Toggle header injection').click();
 
         await expect(popupPage.getByText('Inactive')).toBeVisible();
-        await expect(popupPage.getByText('No active headers')).toBeVisible();
 
         // Verify header is no longer injected
         const page = await context.newPage();


### PR DESCRIPTION
## Summary
- Remove `No active headers` assertion (text no longer exists in single-card layout)
- Replace `Remove` button clicks with toggle switch interaction (`Toggle header injection` aria-label)

These E2E tests were broken by the popup redesign in #42.

## Test plan
- [ ] E2E tests pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)