### PR TITLE
Save without auto-activating; show green dot when active

### DIFF
--- a/e2e/extension.spec.ts
+++ b/e2e/extension.spec.ts
@@ -16,6 +16,11 @@ async function addHeader(
     }
     await popupPage.getByRole('button', { name: 'Save' }).click();
     await expect(popupPage.getByText('Saved!')).toBeVisible();
+
+    // Save no longer auto-installs the DNR rule; flip the toggle on
+    // so tests that assert injected headers still pass.
+    await popupPage.getByLabel('Toggle header injection').click();
+    await expect(popupPage.getByText('Active', { exact: true })).toBeVisible();
 }
 
 test.describe('mirrord browser extension', () => {

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -20,11 +20,8 @@ export async function addHeader(
     await popupPage.getByRole('button', { name: 'Save' }).click();
     await expect(popupPage.getByText('Saved!')).toBeVisible();
 
-    const toggle = popupPage.getByRole('switch', {
-        name: 'Toggle header injection',
-    });
-    if ((await toggle.getAttribute('aria-checked')) !== 'true') {
-        await toggle.click();
-    }
-    await expect(toggle).toHaveAttribute('aria-checked', 'true');
+    // Save no longer auto-installs the DNR rule; flip the toggle on
+    // so tests that assert injected headers still pass.
+    await popupPage.getByLabel('Toggle header injection').click();
+    await expect(popupPage.getByText('Active', { exact: true })).toBeVisible();
 }

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -2,7 +2,9 @@ import type { Page } from '@playwright/test';
 import { expect } from './fixtures';
 
 /**
- * Fill and save a header rule via the popup UI.
+ * Fill, save, and activate a header rule via the popup UI.
+ * Save alone no longer installs the DNR rule; the toggle must be
+ * flipped on for the header to actually inject.
  */
 export async function addHeader(
     popupPage: Page,
@@ -17,4 +19,12 @@ export async function addHeader(
     }
     await popupPage.getByRole('button', { name: 'Save' }).click();
     await expect(popupPage.getByText('Saved!')).toBeVisible();
+
+    const toggle = popupPage.getByRole('switch', {
+        name: 'Toggle header injection',
+    });
+    if ((await toggle.getAttribute('aria-checked')) !== 'true') {
+        await toggle.click();
+    }
+    await expect(toggle).toHaveAttribute('aria-checked', 'true');
 }

--- a/src/__tests__/popup.test.tsx
+++ b/src/__tests__/popup.test.tsx
@@ -208,6 +208,25 @@ describe('Popup', () => {
             ).toBeInTheDocument();
             expect(screen.getByText('All URLs')).toBeInTheDocument();
         });
+
+        // Active dot renders with an explicit green color so it's visible
+        // regardless of what classes the UI kit's CSS bundle includes.
+        const dot = screen.getByTestId('status-dot');
+        expect(dot.style.backgroundColor).toBe('rgb(34, 197, 94)');
+    });
+
+    it('does not set inline green color when inactive', async () => {
+        mockGetDynamicRules.mockImplementation((cb: Function) => cb([]));
+
+        render(<Popup />);
+
+        await waitFor(() => {
+            expect(screen.getByText('Inactive')).toBeInTheDocument();
+        });
+
+        const dot = screen.getByTestId('status-dot');
+        expect(dot.style.backgroundColor).toBe('');
+        expect(dot.className).toContain('bg-muted-foreground/30');
     });
 
     it('renders scoped header rules', async () => {
@@ -473,7 +492,26 @@ describe('Popup', () => {
     });
 
     it('saves header when save button is clicked', async () => {
-        mockGetDynamicRules.mockImplementation((cb: Function) => cb([]));
+        // Rule already active — save should refresh it in place.
+        mockGetDynamicRules.mockImplementation((cb: Function) =>
+            cb([
+                {
+                    id: 1,
+                    priority: 1,
+                    action: {
+                        type: 'modifyHeaders',
+                        requestHeaders: [
+                            {
+                                header: 'X-Old',
+                                operation: 'set',
+                                value: 'old',
+                            },
+                        ],
+                    },
+                    condition: { urlFilter: '|' },
+                },
+            ])
+        );
         mockUpdateDynamicRules.mockImplementation(
             (_opts: unknown, cb: Function) => cb()
         );
@@ -606,7 +644,26 @@ describe('Popup', () => {
     });
 
     it('saves header with URL scope', async () => {
-        mockGetDynamicRules.mockImplementation((cb: Function) => cb([]));
+        // Rule already active — save should refresh it with the new scope.
+        mockGetDynamicRules.mockImplementation((cb: Function) =>
+            cb([
+                {
+                    id: 1,
+                    priority: 1,
+                    action: {
+                        type: 'modifyHeaders',
+                        requestHeaders: [
+                            {
+                                header: 'X-Old',
+                                operation: 'set',
+                                value: 'old',
+                            },
+                        ],
+                    },
+                    condition: { urlFilter: '|' },
+                },
+            ])
+        );
         mockUpdateDynamicRules.mockImplementation(
             (_opts: unknown, cb: Function) => cb()
         );

--- a/src/__tests__/resourceTypes.test.ts
+++ b/src/__tests__/resourceTypes.test.ts
@@ -63,10 +63,34 @@ describe('useHeaderRules resource types', () => {
     });
 
     it('creates rules with all resource types so headers apply to scripts, stylesheets, images, etc.', async () => {
+        // Rule already active — save refreshes it with the full resource-type list.
+        mockGetDynamicRules.mockImplementation((cb) =>
+            cb([
+                {
+                    id: 1,
+                    priority: 1,
+                    action: {
+                        type: 'modifyHeaders',
+                        requestHeaders: [
+                            {
+                                header: 'X-Old',
+                                operation: 'set',
+                                value: 'old',
+                            },
+                        ],
+                    },
+                    condition: { urlFilter: '|' },
+                },
+            ])
+        );
         mockUpdateDynamicRules.mockImplementation((_opts, cb) => cb());
         mockStorageSet.mockImplementation((_data, cb) => cb());
 
         const { result } = renderHook(() => useHeaderRules());
+
+        await act(async () => {
+            // initial load
+        });
 
         act(() => {
             result.current.setHeaderName('X-Test');

--- a/src/__tests__/useHeaderRules.test.ts
+++ b/src/__tests__/useHeaderRules.test.ts
@@ -166,7 +166,7 @@ describe('useHeaderRules analytics', () => {
 
             expect(mockCapture).toHaveBeenCalledWith(
                 'extension_header_rule_saved',
-                { has_scope: false }
+                { has_scope: false, was_active: false }
             );
         });
 
@@ -191,11 +191,110 @@ describe('useHeaderRules analytics', () => {
 
             expect(mockCapture).toHaveBeenCalledWith(
                 'extension_header_rule_saved',
-                { has_scope: true }
+                { has_scope: true, was_active: false }
+            );
+        });
+
+        it('does not update DNR rules when no rules are active (toggle off)', async () => {
+            // No active rules, no config — toggle is off
+            mockGetDynamicRules.mockImplementation(
+                (cb: (rules: chrome.declarativeNetRequest.Rule[]) => void) =>
+                    cb([])
+            );
+            mockStorageSet.mockImplementation(
+                (_data: unknown, cb: () => void) => cb()
+            );
+            const { result } = renderHook(() => useHeaderRules());
+
+            act(() => {
+                result.current.setHeaderName('X-Test');
+                result.current.setHeaderValue('value');
+            });
+
+            await act(async () => {
+                result.current.handleSave();
+            });
+
+            expect(mockUpdateDynamicRules).not.toHaveBeenCalled();
+            expect(mockStorageSet).toHaveBeenCalledTimes(1);
+            expect(mockCapture).toHaveBeenCalledWith(
+                'extension_header_rule_saved',
+                { has_scope: false, was_active: false }
+            );
+        });
+
+        it('updates DNR rules when a rule is already active (toggle on)', async () => {
+            const activeRule: chrome.declarativeNetRequest.Rule = {
+                id: 1,
+                priority: 1,
+                action: {
+                    type: 'modifyHeaders' as chrome.declarativeNetRequest.RuleActionType,
+                    requestHeaders: [
+                        {
+                            header: 'X-Old',
+                            operation:
+                                'set' as chrome.declarativeNetRequest.HeaderOperation,
+                            value: 'old',
+                        },
+                    ],
+                },
+                condition: { urlFilter: '|' },
+            };
+            mockGetDynamicRules.mockImplementation(
+                (cb: (rules: chrome.declarativeNetRequest.Rule[]) => void) =>
+                    cb([activeRule])
+            );
+            mockUpdateDynamicRules.mockImplementation(
+                (_opts: unknown, cb: () => void) => cb()
+            );
+            mockStorageSet.mockImplementation(
+                (_data: unknown, cb: () => void) => cb()
+            );
+
+            const { result } = renderHook(() => useHeaderRules());
+            await act(async () => {
+                // initial load
+            });
+
+            act(() => {
+                result.current.setHeaderName('X-New');
+                result.current.setHeaderValue('new');
+            });
+
+            await act(async () => {
+                result.current.handleSave();
+            });
+
+            expect(mockUpdateDynamicRules).toHaveBeenCalled();
+            expect(mockStorageSet).toHaveBeenCalledTimes(1);
+            expect(mockCapture).toHaveBeenCalledWith(
+                'extension_header_rule_saved',
+                { has_scope: false, was_active: true }
             );
         });
 
         it('sets error on update_rules failure', async () => {
+            // Must have an active rule for the update path to run on save.
+            const activeRule: chrome.declarativeNetRequest.Rule = {
+                id: 1,
+                priority: 1,
+                action: {
+                    type: 'modifyHeaders' as chrome.declarativeNetRequest.RuleActionType,
+                    requestHeaders: [
+                        {
+                            header: 'X-Test',
+                            operation:
+                                'set' as chrome.declarativeNetRequest.HeaderOperation,
+                            value: 'val',
+                        },
+                    ],
+                },
+                condition: { urlFilter: '|' },
+            };
+            mockGetDynamicRules.mockImplementation(
+                (cb: (rules: chrome.declarativeNetRequest.Rule[]) => void) =>
+                    cb([activeRule])
+            );
             mockUpdateDynamicRules.mockImplementation(
                 (_opts: unknown, cb: () => void) => {
                     (
@@ -212,6 +311,9 @@ describe('useHeaderRules analytics', () => {
                 }
             );
             const { result } = renderHook(() => useHeaderRules());
+            await act(async () => {
+                // initial load
+            });
 
             act(() => {
                 result.current.setHeaderName('X-Test');

--- a/src/hooks/useHeaderRules.ts
+++ b/src/hooks/useHeaderRules.ts
@@ -159,29 +159,36 @@ export function useHeaderRules() {
             scope: scope.trim() || undefined,
         };
 
-        const newRules = buildDnrRule(
-            headerName.trim(),
-            headerValue.trim(),
-            scope.trim() || undefined
-        );
+        // Save is non-destructive: only refresh the active DNR rule
+        // if injection is already turned on. If the toggle is off,
+        // saving persists to storage without activating.
+        const wasActive = rules.length > 0;
 
-        try {
-            const existingRules = await getDynamicRules();
-            await updateDynamicRules({
-                removeRuleIds: existingRules.map((r) => r.id),
-                addRules: newRules,
-            });
-        } catch (e) {
-            const msg =
-                e instanceof Error ? e.message : STRINGS.ERR_SAVE_FAILED;
-            setError(`${STRINGS.ERR_SAVE_FAILED}: ${msg}`);
-            setSaveState('idle');
-            capture('extension_error', {
-                action: 'save',
-                step: 'update_rules',
-                error: msg,
-            });
-            return;
+        if (wasActive) {
+            const newRules = buildDnrRule(
+                headerName.trim(),
+                headerValue.trim(),
+                scope.trim() || undefined
+            );
+
+            try {
+                const existingRules = await getDynamicRules();
+                await updateDynamicRules({
+                    removeRuleIds: existingRules.map((r) => r.id),
+                    addRules: newRules,
+                });
+            } catch (e) {
+                const msg =
+                    e instanceof Error ? e.message : STRINGS.ERR_SAVE_FAILED;
+                setError(`${STRINGS.ERR_SAVE_FAILED}: ${msg}`);
+                setSaveState('idle');
+                capture('extension_error', {
+                    action: 'save',
+                    step: 'update_rules',
+                    error: msg,
+                });
+                return;
+            }
         }
 
         try {
@@ -205,8 +212,9 @@ export function useHeaderRules() {
         setTimeout(() => setSaveState('idle'), 1500);
         capture('extension_header_rule_saved', {
             has_scope: !!scope.trim(),
+            was_active: wasActive,
         });
-    }, [headerName, headerValue, scope, loadRules]);
+    }, [headerName, headerValue, scope, loadRules, rules]);
 
     const handleReset = useCallback(async () => {
         setError(null);

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -121,11 +121,15 @@ export function Popup() {
                         <div className="flex items-center justify-between">
                             <div className="flex items-center gap-2">
                                 <span
+                                    data-testid="status-dot"
                                     className={`inline-block w-2 h-2 rounded-full transition-colors ${
-                                        isActive
-                                            ? 'bg-green-500'
-                                            : 'bg-muted-foreground/30'
+                                        isActive ? '' : 'bg-muted-foreground/30'
                                     }`}
+                                    style={
+                                        isActive
+                                            ? { backgroundColor: '#22c55e' }
+                                            : undefined
+                                    }
                                 />
                                 <span className="text-xs font-medium">
                                     {isActive ? 'Active' : 'Inactive'}


### PR DESCRIPTION
## Summary

Two small fixes to the popup:

1. **Save no longer auto-activates.** Previously, clicking Save always installed a DNR rule, flipping the toggle on even if the user had it off. Now Save is non-destructive: if the toggle is off, save only writes to storage; the toggle stays off. If it's on, save refreshes the active rule with the new values so state stays consistent.
2. **Active status dot was invisible.** `bg-green-500` isn't in `@metalbear/ui`'s compiled CSS, so when active the dot rendered as empty. Switched to an inline `#22c55e` so it renders regardless of which Tailwind classes the kit ships with.

## Changes

- `src/hooks/useHeaderRules.ts` — gate the DNR update on `rules.length > 0`; add `was_active` to the `extension_header_rule_saved` analytics event.
- `src/popup.tsx` — inline `backgroundColor: '#22c55e'` when active; add `data-testid="status-dot"` for testability.

## Tests

- Added: `handleSave` does not call `updateDynamicRules` when no rule is active (toggle off).
- Added: `handleSave` refreshes the active rule when one is active (toggle on).
- Added: status dot renders green when active, grey-class when inactive.
- Updated existing tests that assumed save always hits DNR to set up an active rule first.

All 122 tests pass, lint clean.

## Test plan

- [x] `pnpm test` (unit, 122 passing)
- [x] `pnpm run check` (prettier + eslint clean)
- [x] `pnpm build`
- [x] Loaded unpacked and verified:
  - Fresh popup → toggle off → Save → toggle stays off (was flipping on before)
  - Toggle on → change value → Save → toggle stays on, rule refreshes
  - Green dot visible when active, grey dot when inactive

🤖 Generated with [Claude Code](https://claude.com/claude-code)