### PR TITLE
Bump version to 0.2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mirrord-browser",
-    "version": "0.2.5",
+    "version": "0.2.6",
     "description": "Browser extension for mirrord",
     "type": "module",
     "scripts": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 3,
     "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAoasM13FWg9dB6ufOs6gHQKfExEmQkaXR7uVMRtJPvmLQB8EnivUNLGQ0b8OZ5Eggn21oXNgdEl7WhcKLuK20cHcW61TE7XAKIcV6uDmlc1FJFczxpqI7L+GgeeAtiC9vkHFulBHmfCxq4z8+zqNRLpwZ6xMyt6j9rJ7V1h7Uv0n4shf6xG0ukyTpfAc64Pkp4GtG+bdy51ki9XE0pJEnyotk5I9eGKp/3kL0EAQW0a9ES/5LM+fFwPU2EWZlqkx07zd1AnlzzQ4kz2rceBUIkI/x1mPyzNkPlnOtvlNUooFq8J5L3be2n1pZS099OM5ZLKKjomARcr/iiqgrjdkXAQIDAQAB",
     "name": "mirrord",
-    "version": "0.2.5",
+    "version": "0.2.6",
     "description": "More user-friendly testing with mirrord by automatically injecting HTTP header",
     "icons": {
         "48": "images/mirrord.png"


### PR DESCRIPTION
Version bump for release. Tags `v0.2.6` after merge triggers Chrome Web Store upload.