### PR TITLE
feat(mirrord-browser): URL scope chips on live banner + session search

### DIFF
--- a/src/__tests__/SessionsView.test.tsx
+++ b/src/__tests__/SessionsView.test.tsx
@@ -76,6 +76,10 @@ jest.mock('@metalbear/ui', () => ({
     }: React.PropsWithChildren<{ value?: string }>) => (
         <div data-value={value}>{children}</div>
     ),
+    Input: React.forwardRef<
+        HTMLInputElement,
+        React.InputHTMLAttributes<HTMLInputElement>
+    >((props, ref) => <input ref={ref} {...props} />),
 }));
 
 import { SessionsView } from '../components/SessionsView';
@@ -115,6 +119,9 @@ describe('SessionsView', () => {
         onJoin: jest.fn(),
         onClear: jest.fn(),
         onShare: jest.fn(),
+        scopePatterns: [] as string[],
+        onAddScopePattern: jest.fn(),
+        onRemoveScopePattern: jest.fn(),
     };
 
     test('renders one group per key, omitting keyless sessions', () => {

--- a/src/components/ConnectedBanner.tsx
+++ b/src/components/ConnectedBanner.tsx
@@ -1,4 +1,6 @@
-import { Button } from '@metalbear/ui';
+import { useState, useRef, useEffect } from 'react';
+import { Globe, X } from 'lucide-react';
+import { Button, Input } from '@metalbear/ui';
 import type { OperatorSessionSummary } from '../types';
 import { STRINGS } from '../constants';
 import { COLORS } from '../colors';
@@ -9,9 +11,19 @@ type Props = {
     session: OperatorSessionSummary | undefined;
     sessionEnded: boolean;
     onLeave: () => void;
+    scopePatterns: string[];
+    onAddScopePattern: (pattern: string) => void | Promise<void>;
+    onRemoveScopePattern: (pattern: string) => void | Promise<void>;
 };
 
-export function ConnectedBanner({ joinedKey, sessionEnded, onLeave }: Props) {
+export function ConnectedBanner({
+    joinedKey,
+    sessionEnded,
+    onLeave,
+    scopePatterns,
+    onAddScopePattern,
+    onRemoveScopePattern,
+}: Props) {
     const label = sessionEnded
         ? STRINGS.MSG_SESSION_ENDED
         : STRINGS.MSG_SESSION_LIVE;
@@ -24,9 +36,24 @@ export function ConnectedBanner({ joinedKey, sessionEnded, onLeave }: Props) {
         ? COLORS.destructive.solid
         : COLORS.brand.lilac;
 
+    const [draft, setDraft] = useState('');
+    const inputRef = useRef<HTMLInputElement | null>(null);
+
+    useEffect(() => {
+        if (sessionEnded && draft) setDraft('');
+    }, [sessionEnded, draft]);
+
+    const submit = async () => {
+        const trimmed = draft.trim();
+        if (!trimmed) return;
+        await onAddScopePattern(trimmed);
+        setDraft('');
+        inputRef.current?.focus();
+    };
+
     return (
         <div
-            className="flex items-center"
+            className="flex flex-col"
             style={{
                 gap: 10,
                 padding: '10px 12px',
@@ -35,42 +62,137 @@ export function ConnectedBanner({ joinedKey, sessionEnded, onLeave }: Props) {
                 background: bg,
             }}
         >
-            <StatusDot tone={sessionEnded ? 'destructive' : 'active'} glow />
-            <div className="min-w-0" style={{ flex: 1 }}>
-                <div
-                    className="font-semibold"
-                    style={{
-                        fontSize: 10.5,
-                        letterSpacing: '0.08em',
-                        textTransform: 'uppercase',
-                        color: titleColor,
-                    }}
-                >
-                    {label}
+            <div className="flex items-center" style={{ gap: 10 }}>
+                <StatusDot
+                    tone={sessionEnded ? 'destructive' : 'active'}
+                    glow
+                />
+                <div className="min-w-0" style={{ flex: 1 }}>
+                    <div
+                        className="font-semibold"
+                        style={{
+                            fontSize: 10.5,
+                            letterSpacing: '0.08em',
+                            textTransform: 'uppercase',
+                            color: titleColor,
+                        }}
+                    >
+                        {label}
+                    </div>
+                    <div
+                        className="font-mono"
+                        style={{
+                            fontSize: 13,
+                            fontWeight: 500,
+                            marginTop: 1,
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap',
+                        }}
+                    >
+                        {joinedKey}
+                    </div>
                 </div>
-                <div
-                    className="font-mono"
-                    style={{
-                        fontSize: 13,
-                        fontWeight: 500,
-                        marginTop: 1,
-                        overflow: 'hidden',
-                        textOverflow: 'ellipsis',
-                        whiteSpace: 'nowrap',
-                    }}
+                <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    onClick={onLeave}
+                    style={{ height: 28, padding: '0 12px' }}
                 >
-                    {joinedKey}
-                </div>
+                    {buttonLabel}
+                </Button>
             </div>
-            <Button
-                type="button"
-                size="sm"
-                variant="outline"
-                onClick={onLeave}
-                style={{ height: 28, padding: '0 12px' }}
-            >
-                {buttonLabel}
-            </Button>
+
+            {!sessionEnded && (
+                <div
+                    className="flex flex-col"
+                    style={{
+                        gap: 8,
+                        paddingTop: 8,
+                        borderTop: `1px dashed ${COLORS.primary.borderSubtle}`,
+                    }}
+                >
+                    <div
+                        className="flex items-center justify-between"
+                        style={{ fontSize: 10.5 }}
+                    >
+                        <span
+                            className="inline-flex items-center text-muted-foreground font-semibold"
+                            style={{
+                                gap: 6,
+                                letterSpacing: '0.08em',
+                                textTransform: 'uppercase',
+                            }}
+                        >
+                            <Globe style={{ height: 12, width: 12 }} />
+                            {STRINGS.LABEL_URL_SCOPE_HEADING}
+                        </span>
+                        <span className="text-muted-foreground">
+                            {STRINGS.MSG_PATTERN_COUNT(scopePatterns.length)}
+                        </span>
+                    </div>
+                    <div
+                        className="flex flex-wrap items-center"
+                        style={{ gap: 6 }}
+                    >
+                        {scopePatterns.map((pattern) => (
+                            <span
+                                key={pattern}
+                                className="inline-flex items-center font-mono"
+                                style={{
+                                    gap: 6,
+                                    fontSize: 11,
+                                    padding: '4px 6px 4px 8px',
+                                    borderRadius: 6,
+                                    border: `1px solid ${COLORS.primary.border}`,
+                                    background: COLORS.primary.tint,
+                                    color: COLORS.brand.lilac,
+                                }}
+                            >
+                                {pattern}
+                                <button
+                                    type="button"
+                                    aria-label={STRINGS.LABEL_REMOVE_PATTERN}
+                                    onClick={() =>
+                                        onRemoveScopePattern(pattern)
+                                    }
+                                    className="inline-flex items-center justify-center text-muted-foreground hover:text-foreground"
+                                    style={{
+                                        height: 16,
+                                        width: 16,
+                                        borderRadius: 4,
+                                    }}
+                                >
+                                    <X style={{ height: 12, width: 12 }} />
+                                </button>
+                            </span>
+                        ))}
+                        <Input
+                            ref={inputRef}
+                            value={draft}
+                            onChange={(e) => setDraft(e.target.value)}
+                            onKeyDown={(e) => {
+                                if (e.key === 'Enter') {
+                                    e.preventDefault();
+                                    submit();
+                                }
+                            }}
+                            onBlur={submit}
+                            placeholder={STRINGS.PLACEHOLDER_URL_PATTERN}
+                            spellCheck={false}
+                            autoComplete="off"
+                            className="font-mono"
+                            style={{
+                                flex: 1,
+                                minWidth: 120,
+                                height: 28,
+                                fontSize: 11,
+                            }}
+                        />
+                    </div>
+                </div>
+            )}
         </div>
     );
 }

--- a/src/components/SessionsView.tsx
+++ b/src/components/SessionsView.tsx
@@ -1,4 +1,7 @@
+import { useMemo, useState } from 'react';
+import { Search } from 'lucide-react';
 import groupBy from 'lodash.groupby';
+import { Input } from '@metalbear/ui';
 import { SessionKeyGroup } from './SessionKeyGroup';
 import { ConnectedBanner } from './ConnectedBanner';
 import { NamespaceFilter } from './NamespaceFilter';
@@ -20,7 +23,27 @@ type Props = {
     onJoin: (key: string) => void;
     onClear: () => void;
     onShare: (key: string) => void;
+    scopePatterns: string[];
+    onAddScopePattern: (pattern: string) => void | Promise<void>;
+    onRemoveScopePattern: (pattern: string) => void | Promise<void>;
 };
+
+function matchesQuery(s: OperatorSessionSummary, q: string): boolean {
+    if (!q) return true;
+    const haystack = [
+        s.key,
+        s.namespace,
+        s.owner?.username,
+        s.owner?.k8sUsername,
+        s.target ? `${s.target.kind}/${s.target.name}` : '',
+        s.target?.name,
+        s.target?.container,
+    ]
+        .filter(Boolean)
+        .join(' ')
+        .toLowerCase();
+    return haystack.includes(q);
+}
 
 export function SessionsView({
     sessions,
@@ -33,7 +56,11 @@ export function SessionsView({
     onJoin,
     onClear,
     onShare,
+    scopePatterns,
+    onAddScopePattern,
+    onRemoveScopePattern,
 }: Props) {
+    const [query, setQuery] = useState('');
     if (!sessionsLoaded) {
         return <NotConfiguredPrompt />;
     }
@@ -44,9 +71,14 @@ export function SessionsView({
     const joinedVanished = joinState.joinedKey !== null && !joinedSession;
     const effectiveSessionEnded = joinState.sessionEnded || joinedVanished;
 
-    const filtered = namespace
-        ? sessions.filter((s) => s.namespace === namespace)
-        : sessions;
+    const normalizedQuery = query.trim().toLowerCase();
+    const filtered = useMemo(() => {
+        return sessions.filter(
+            (s) =>
+                (!namespace || s.namespace === namespace) &&
+                matchesQuery(s, normalizedQuery)
+        );
+    }, [sessions, namespace, normalizedQuery]);
     const groups = groupBy(filtered, (s) => s.key);
 
     const joinedKey = joinState.joinedKey;
@@ -60,6 +92,10 @@ export function SessionsView({
     const watching = status?.status === 'watching';
     const operatorUnavailable = status?.status === 'unavailable';
     const hasGroups = orderedKeys.length > 0;
+    const totalSessionsBeforeQuery = namespace
+        ? sessions.filter((s) => s.namespace === namespace).length
+        : sessions.length;
+    const showSearch = totalSessionsBeforeQuery > 0;
 
     return (
         <div className="flex flex-col" style={{ gap: 10 }}>
@@ -69,10 +105,58 @@ export function SessionsView({
                     session={joinedSession}
                     sessionEnded={effectiveSessionEnded}
                     onLeave={onClear}
+                    scopePatterns={scopePatterns}
+                    onAddScopePattern={onAddScopePattern}
+                    onRemoveScopePattern={onRemoveScopePattern}
                 />
             )}
 
             {operatorUnavailable && <OperatorUnavailableNote />}
+
+            {showSearch && (
+                <div className="flex items-center" style={{ gap: 8 }}>
+                    <div
+                        className="flex items-center"
+                        style={{
+                            flex: 1,
+                            position: 'relative',
+                        }}
+                    >
+                        <Search
+                            className="text-muted-foreground"
+                            style={{
+                                position: 'absolute',
+                                left: 10,
+                                height: 13,
+                                width: 13,
+                                pointerEvents: 'none',
+                            }}
+                        />
+                        <Input
+                            value={query}
+                            onChange={(e) => setQuery(e.target.value)}
+                            placeholder={STRINGS.PLACEHOLDER_SEARCH_SESSIONS}
+                            aria-label={STRINGS.LABEL_SEARCH_SESSIONS}
+                            spellCheck={false}
+                            autoComplete="off"
+                            className="font-mono"
+                            style={{
+                                width: '100%',
+                                height: 32,
+                                paddingLeft: 30,
+                                fontSize: 11,
+                            }}
+                        />
+                    </div>
+                    {hasNamespaces && (
+                        <NamespaceFilter
+                            namespaces={namespaces}
+                            value={namespace}
+                            onChange={setNamespace}
+                        />
+                    )}
+                </div>
+            )}
 
             {hasGroups && (
                 <>
@@ -85,7 +169,9 @@ export function SessionsView({
                             textTransform: 'uppercase',
                         }}
                     >
-                        <span>{STRINGS.MSG_LIVE_SESSIONS}</span>
+                        <span>
+                            {filtered.length} {STRINGS.MSG_LIVE_SESSIONS}
+                        </span>
                         {status && (
                             <span
                                 className="inline-flex items-center"
@@ -98,14 +184,6 @@ export function SessionsView({
                             </span>
                         )}
                     </div>
-
-                    {hasNamespaces && (
-                        <NamespaceFilter
-                            namespaces={namespaces}
-                            value={namespace}
-                            onChange={setNamespace}
-                        />
-                    )}
 
                     <div className="flex flex-col" style={{ gap: 10 }}>
                         {orderedKeys.map((k) => (
@@ -132,7 +210,9 @@ export function SessionsView({
                         margin: 0,
                     }}
                 >
-                    {STRINGS.MSG_NO_ACTIVE_SESSIONS}
+                    {totalSessionsBeforeQuery > 0
+                        ? STRINGS.MSG_NO_SESSIONS_MATCH_QUERY
+                        : STRINGS.MSG_NO_ACTIVE_SESSIONS}
                 </p>
             )}
         </div>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -70,7 +70,14 @@ export const STRINGS = {
         'Run mirrord ui first and open the configure URL it prints.',
 
     TAB_SESSIONS: 'Sessions',
-    TAB_MANUAL: 'Manual',
+    TAB_MANUAL: 'Override',
+    LABEL_URL_SCOPE_HEADING: 'URL scope',
+    PLACEHOLDER_URL_PATTERN: '+ pattern',
+    LABEL_REMOVE_PATTERN: 'Remove pattern',
+    PLACEHOLDER_SEARCH_SESSIONS: 'search by key, target, owner',
+    LABEL_SEARCH_SESSIONS: 'Search sessions',
+    MSG_NO_SESSIONS_MATCH_QUERY: 'No sessions match your search.',
+    MSG_PATTERN_COUNT: (n: number) => `${n} pattern${n === 1 ? '' : 's'}`,
 
     ERR_HEADER_REQUIRED: 'Header name and value are required',
     ERR_REMOVE_RULE: 'Failed to remove rule',

--- a/src/hooks/useMirrordUi.ts
+++ b/src/hooks/useMirrordUi.ts
@@ -68,6 +68,9 @@ const BAGGAGE_VALUE_PREFIX = 'mirrord-session=';
 const WATCHED_STORAGE_KEYS: readonly string[] = [
     STORAGE_KEYS.JOINED_KEY,
     STORAGE_KEYS.JOINED_SESSION_NAME,
+    STORAGE_KEYS.JOINED_HEADER,
+    STORAGE_KEYS.JOINED_VALUE,
+    STORAGE_KEYS.SCOPE_PATTERNS,
     STORAGE_KEYS.MIRRORD_UI_BACKEND,
     STORAGE_KEYS.MIRRORD_UI_TOKEN,
 ];
@@ -105,6 +108,9 @@ export function useMirrordUi() {
         joinedSessionName: null,
         sessionEnded: false,
     });
+    const [scopePatterns, setScopePatternsState] = useState<string[]>([]);
+    const joinedHeaderRef = useRef<string | null>(null);
+    const joinedValueRef = useRef<string | null>(null);
 
     const wsRef = useRef<WebSocket | null>(null);
 
@@ -116,6 +122,9 @@ export function useMirrordUi() {
                 STORAGE_KEYS.MIRRORD_UI_TOKEN,
                 STORAGE_KEYS.JOINED_KEY,
                 STORAGE_KEYS.JOINED_SESSION_NAME,
+                STORAGE_KEYS.JOINED_HEADER,
+                STORAGE_KEYS.JOINED_VALUE,
+                STORAGE_KEYS.SCOPE_PATTERNS,
             ]);
             if (cancelled) return;
             setBackend(
@@ -129,6 +138,18 @@ export function useMirrordUi() {
                     null,
                 sessionEnded: false,
             });
+            joinedHeaderRef.current =
+                (stored[STORAGE_KEYS.JOINED_HEADER] as string) ?? null;
+            joinedValueRef.current =
+                (stored[STORAGE_KEYS.JOINED_VALUE] as string) ?? null;
+            const persisted = stored[STORAGE_KEYS.SCOPE_PATTERNS];
+            setScopePatternsState(
+                Array.isArray(persisted)
+                    ? (persisted as string[]).filter(
+                          (p) => typeof p === 'string'
+                      )
+                    : []
+            );
         };
 
         loadFromStorage();
@@ -240,19 +261,23 @@ export function useMirrordUi() {
             const existing = await getDynamicRules();
             await updateDynamicRules({
                 removeRuleIds: existing.map((r) => r.id),
-                addRules: buildDnrRule(header, value),
+                addRules: buildDnrRule(header, value, scopePatterns),
             });
             await storageSet({
                 [STORAGE_KEYS.JOINED_KEY]: key,
                 [STORAGE_KEYS.JOINED_SESSION_NAME]: target.id,
+                [STORAGE_KEYS.JOINED_HEADER]: header,
+                [STORAGE_KEYS.JOINED_VALUE]: value,
             });
+            joinedHeaderRef.current = header;
+            joinedValueRef.current = value;
             setJoinState({
                 joinedKey: key,
                 joinedSessionName: target.id,
                 sessionEnded: false,
             });
         },
-        [sessions]
+        [sessions, scopePatterns]
     );
 
     const clearJoin = useCallback(async () => {
@@ -264,13 +289,46 @@ export function useMirrordUi() {
         await storageRemove([
             STORAGE_KEYS.JOINED_KEY,
             STORAGE_KEYS.JOINED_SESSION_NAME,
+            STORAGE_KEYS.JOINED_HEADER,
+            STORAGE_KEYS.JOINED_VALUE,
+            STORAGE_KEYS.SCOPE_PATTERNS,
         ]);
+        joinedHeaderRef.current = null;
+        joinedValueRef.current = null;
+        setScopePatternsState([]);
         setJoinState({
             joinedKey: null,
             joinedSessionName: null,
             sessionEnded: false,
         });
     }, []);
+
+    const applyScopePatterns = useCallback(async (next: string[]) => {
+        const cleaned = next.map((p) => p.trim()).filter((p) => p.length > 0);
+        const dedup = Array.from(new Set(cleaned));
+        await storageSet({ [STORAGE_KEYS.SCOPE_PATTERNS]: dedup });
+        setScopePatternsState(dedup);
+        const header = joinedHeaderRef.current;
+        const value = joinedValueRef.current;
+        if (header && value) {
+            const existing = await getDynamicRules();
+            await updateDynamicRules({
+                removeRuleIds: existing.map((r) => r.id),
+                addRules: buildDnrRule(header, value, dedup),
+            });
+        }
+    }, []);
+
+    const addScopePattern = useCallback(
+        (pattern: string) => applyScopePatterns([...scopePatterns, pattern]),
+        [scopePatterns, applyScopePatterns]
+    );
+
+    const removeScopePattern = useCallback(
+        (pattern: string) =>
+            applyScopePatterns(scopePatterns.filter((p) => p !== pattern)),
+        [scopePatterns, applyScopePatterns]
+    );
 
     const buildShareUrl = useCallback(
         (key: string): string => {
@@ -297,6 +355,9 @@ export function useMirrordUi() {
         join,
         clearJoin,
         buildShareUrl,
+        scopePatterns,
+        addScopePattern,
+        removeScopePattern,
     };
 }
 

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -94,7 +94,26 @@ export function Popup() {
                 >
                     <TabsList className="grid grid-cols-2 w-full">
                         <TabsTrigger value={TAB.SESSIONS}>
-                            {STRINGS.TAB_SESSIONS}
+                            <span className="inline-flex items-center gap-1.5">
+                                {STRINGS.TAB_SESSIONS}
+                                {(mirrordUi.sessions?.sessions.length ?? 0) >
+                                    0 && (
+                                    <span
+                                        className="font-mono"
+                                        style={{
+                                            fontSize: 10,
+                                            padding: '1px 6px',
+                                            borderRadius: 999,
+                                            background:
+                                                'hsl(var(--background))',
+                                            color: 'hsl(var(--foreground))',
+                                            lineHeight: 1.4,
+                                        }}
+                                    >
+                                        {mirrordUi.sessions?.sessions.length}
+                                    </span>
+                                )}
+                            </span>
                         </TabsTrigger>
                         <TabsTrigger value={TAB.MANUAL}>
                             {STRINGS.TAB_MANUAL}
@@ -132,6 +151,9 @@ function SessionsScreen({
                 const url = mirrordUi.buildShareUrl(key);
                 navigator.clipboard.writeText(url).catch(() => {});
             }}
+            scopePatterns={mirrordUi.scopePatterns}
+            onAddScopePattern={mirrordUi.addScopePattern}
+            onRemoveScopePattern={mirrordUi.removeScopePattern}
         />
     );
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,9 @@ export const STORAGE_KEYS = {
     MIRRORD_UI_TOKEN: 'mirrord_ui_token',
     JOINED_KEY: 'joined_key',
     JOINED_SESSION_NAME: 'joined_session_name',
+    JOINED_HEADER: 'joined_header',
+    JOINED_VALUE: 'joined_value',
+    SCOPE_PATTERNS: 'scope_patterns',
 } as const;
 
 export const ALL_RESOURCE_TYPES: chrome.declarativeNetRequest.ResourceType[] = [

--- a/src/util.ts
+++ b/src/util.ts
@@ -45,30 +45,32 @@ export function parseRules(
 export function buildDnrRule(
     header: string,
     value: string,
-    scope?: string
+    scope?: string | string[]
 ): chrome.declarativeNetRequest.Rule[] {
-    return [
-        {
-            id: 1,
-            priority: 1,
-            action: {
-                type: chrome.declarativeNetRequest.RuleActionType
-                    .MODIFY_HEADERS,
-                requestHeaders: [
-                    {
-                        header,
-                        operation:
-                            chrome.declarativeNetRequest.HeaderOperation.SET,
-                        value,
-                    },
-                ],
-            },
-            condition: {
-                urlFilter: scope || '|',
-                resourceTypes: ALL_RESOURCE_TYPES,
-            },
+    const patterns = Array.isArray(scope)
+        ? scope.filter((p) => p.trim().length > 0)
+        : scope && scope.trim().length > 0
+          ? [scope]
+          : [];
+    const filters = patterns.length > 0 ? patterns : ['|'];
+    return filters.map((urlFilter, idx) => ({
+        id: idx + 1,
+        priority: 1,
+        action: {
+            type: chrome.declarativeNetRequest.RuleActionType.MODIFY_HEADERS,
+            requestHeaders: [
+                {
+                    header,
+                    operation: chrome.declarativeNetRequest.HeaderOperation.SET,
+                    value,
+                },
+            ],
         },
-    ];
+        condition: {
+            urlFilter,
+            resourceTypes: ALL_RESOURCE_TYPES,
+        },
+    }));
 }
 
 export function getDynamicRules(): Promise<


### PR DESCRIPTION
## Summary

Sessions tab redesign matching the latest mockup. Two user-facing improvements:

1. **URL scope chips on the SESSION LIVE banner.** A joined user can now scope the injected header to specific URL patterns without leaving the Sessions tab. Empty list keeps today's inject-globally behavior. Each pattern becomes its own Chrome DNR rule sharing the same modify-headers action. Patterns persist in chrome.storage.local across popup opens.
2. **Search by key, target, owner, namespace.** Search input above the session list does a case-insensitive substring match. Hidden when the operator returns zero sessions. The Live sessions header reflects the post-filter count, and empty-after-search uses a distinct message.

Also:
- Manual tab → Override (per design).
- Sessions tab trigger has a count badge.
- clearJoin / Leave wipes scope patterns and the joined header+value alongside the joined key.

## Implementation notes

- \`buildDnrRule(header, value, scope)\` now accepts a string or string[]. With N patterns it returns N rules; the existing single-pattern callers still work.
- \`useMirrordUi\` persists \`joined_header\`, \`joined_value\`, and \`scope_patterns\`. When patterns change while joined, rules rebuild from the persisted header+value without needing the operator list.
- All existing Sessions / popup / hook tests still pass; SessionsView mock updated to expose Input.

## Out of scope (would need follow-up + operator changes)

- Per-session card layout (current is per-key, since http_filter is shared per key).
- Method/path filter display on cards (operator currently only exposes \`headerFilter\`).
- Sort selector and group-key header treatment.

## Test plan

- [x] \`pnpm test\` (Jest, 144 tests pass)
- [x] \`pnpm build\`
- [x] \`pnpm run check\` (prettier + eslint clean)
- [ ] Manual: load unpacked dist/, run \`mirrord ui\`, join a session against playground, add patterns, verify x-mirrord-user header only injects on matching URLs (DevTools Network).
- [ ] Manual: search filters by key, target, owner, namespace.
- [ ] Manual: pattern persistence across popup close/open.
- [ ] Manual: leave clears patterns; rejoining starts with empty pattern list.