### PR TITLE
feat(mirrord-browser): session share links use manual configure, join…

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,6 +59,7 @@ jobs:
         name: E2E Tests
         runs-on: ubuntu-latest
         needs: lint-and-format
+        timeout-minutes: 20
 
         steps:
             - name: Checkout code
@@ -80,6 +81,12 @@ jobs:
 
             - name: Install Playwright Chromium
               run: pnpm exec playwright install chromium --with-deps
+              env:
+                  # `--with-deps` runs apt via sudo; on newer ubuntu-latest images the
+                  # needrestart prompt blocks the install until the job timeout. Force
+                  # both apt and needrestart non-interactive so it can't hang.
+                  DEBIAN_FRONTEND: noninteractive
+                  NEEDRESTART_MODE: a
 
             - name: Run E2E tests
               run: xvfb-run pnpm test:e2e

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -65,6 +65,17 @@ describe('parseHeader', () => {
         expect(() => parseHeader('KeyOnly:')).toThrow();
         expect(() => parseHeader(':ValueOnly')).toThrow();
     });
+
+    it('keeps colons in the value (splits on the first colon only)', () => {
+        expect(parseHeader('X-Forwarded: host:8080')).toEqual({
+            key: 'X-Forwarded',
+            value: 'host:8080',
+        });
+        expect(parseHeader('baggage: mirrord-session=k1')).toEqual({
+            key: 'baggage',
+            value: 'mirrord-session=k1',
+        });
+    });
 });
 
 describe('decodeConfig', () => {

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -4,20 +4,37 @@ import {
     decodeConfig,
     promptForValidHeader,
     storeDefaults,
+    storeOverride,
+    joinMatchingSession,
 } from '../config';
 import { STORAGE_KEYS } from '../types';
+import type { OperatorSessionSummary } from '../types';
 
 // Mock the chrome API for storage tests
 const mockStorageSet = jest.fn();
+const mockStorageGet = jest.fn();
+const mockGetDynamicRules = jest.fn();
+const mockUpdateDynamicRules = jest.fn();
 
 globalThis.chrome = {
     storage: {
         local: {
             set: mockStorageSet,
+            get: mockStorageGet,
         },
     },
     runtime: {
         lastError: null,
+    },
+    declarativeNetRequest: {
+        getDynamicRules: mockGetDynamicRules,
+        updateDynamicRules: mockUpdateDynamicRules,
+        RuleActionType: { MODIFY_HEADERS: 'modifyHeaders' },
+        HeaderOperation: { SET: 'set' },
+    },
+    action: {
+        setBadgeText: jest.fn(),
+        setBadgeTextColor: jest.fn(),
     },
 } as any;
 
@@ -304,8 +321,155 @@ describe('storeDefaults', () => {
         await storeDefaults('X-Test-Header', 'test-value');
 
         expect(consoleSpy).toHaveBeenCalledWith(
-            'Defaults stored successfully.'
+            'defaults stored successfully.'
         );
         consoleSpy.mockRestore();
+    });
+});
+
+describe('storeOverride', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        (chrome.runtime as any).lastError = null;
+    });
+
+    it('stores header name and value as an override', async () => {
+        mockStorageSet.mockImplementation((_data, callback) => callback());
+
+        await storeOverride('X-Test-Header', 'test-value');
+
+        expect(mockStorageSet).toHaveBeenCalledWith(
+            {
+                [STORAGE_KEYS.OVERRIDE]: {
+                    headerName: 'X-Test-Header',
+                    headerValue: 'test-value',
+                    scope: undefined,
+                },
+            },
+            expect.any(Function)
+        );
+    });
+});
+
+describe('joinMatchingSession', () => {
+    const session: OperatorSessionSummary = {
+        id: 'sess-1',
+        key: 'k1',
+        namespace: 'default',
+        owner: { username: 'alice', k8sUsername: 'alice@ex' },
+        target: null,
+        createdAt: '2026-01-01T00:00:00Z',
+    };
+
+    const sessionsResponse = (sessions: OperatorSessionSummary[]) => ({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        text: () => Promise.resolve(''),
+        json: () =>
+            Promise.resolve({
+                sessions,
+                by_key: {},
+                watch_status: { status: 'watching' },
+            }),
+    });
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        (chrome.runtime as any).lastError = null;
+        mockStorageGet.mockImplementation((_keys, callback) =>
+            callback({
+                [STORAGE_KEYS.MIRRORD_UI_BACKEND]: 'http://127.0.0.1:9000',
+                [STORAGE_KEYS.MIRRORD_UI_TOKEN]: 'tok',
+            })
+        );
+        mockStorageSet.mockImplementation((_data, callback) => callback());
+        mockGetDynamicRules.mockImplementation((callback) =>
+            callback([{ id: 7 }])
+        );
+        mockUpdateDynamicRules.mockImplementation((_opts, callback) =>
+            callback()
+        );
+        global.fetch = jest.fn().mockResolvedValue(sessionsResponse([session]));
+    });
+
+    it('joins the live session whose baggage value matches', async () => {
+        const joined = await joinMatchingSession(
+            'baggage',
+            'mirrord-session=k1'
+        );
+
+        expect(joined).toBe('k1');
+        expect(mockUpdateDynamicRules).toHaveBeenCalledWith(
+            expect.objectContaining({ removeRuleIds: [7] }),
+            expect.any(Function)
+        );
+        expect(mockStorageSet).toHaveBeenCalledWith(
+            {
+                [STORAGE_KEYS.JOINED_KEY]: 'k1',
+                [STORAGE_KEYS.JOINED_SESSION_NAME]: 'sess-1',
+                [STORAGE_KEYS.JOINED_HEADER]: 'baggage',
+                [STORAGE_KEYS.JOINED_VALUE]: 'mirrord-session=k1',
+            },
+            expect.any(Function)
+        );
+    });
+
+    it('matches the header name case-insensitively against the http filter', async () => {
+        (global.fetch as jest.Mock).mockResolvedValue(
+            sessionsResponse([
+                {
+                    ...session,
+                    httpFilter: { headerFilter: '^x-tenant: alice$' },
+                },
+            ])
+        );
+
+        const joined = await joinMatchingSession('X-Tenant', 'alice');
+
+        expect(joined).toBe('k1');
+        expect(mockStorageSet).toHaveBeenCalledWith(
+            expect.objectContaining({
+                [STORAGE_KEYS.JOINED_HEADER]: 'x-tenant',
+                [STORAGE_KEYS.JOINED_VALUE]: 'alice',
+            }),
+            expect.any(Function)
+        );
+    });
+
+    it('returns null when mirrord ui is not configured', async () => {
+        mockStorageGet.mockImplementation((_keys, callback) => callback({}));
+
+        const joined = await joinMatchingSession(
+            'baggage',
+            'mirrord-session=k1'
+        );
+
+        expect(joined).toBeNull();
+        expect(global.fetch).not.toHaveBeenCalled();
+        expect(mockUpdateDynamicRules).not.toHaveBeenCalled();
+    });
+
+    it('returns null when no live session matches', async () => {
+        const joined = await joinMatchingSession(
+            'baggage',
+            'mirrord-session=other'
+        );
+
+        expect(joined).toBeNull();
+        expect(mockUpdateDynamicRules).not.toHaveBeenCalled();
+        expect(mockStorageSet).not.toHaveBeenCalled();
+    });
+
+    it('returns null when fetching sessions fails', async () => {
+        (global.fetch as jest.Mock).mockRejectedValue(new Error('boom'));
+
+        const joined = await joinMatchingSession(
+            'baggage',
+            'mirrord-session=k1'
+        );
+
+        expect(joined).toBeNull();
+        expect(mockUpdateDynamicRules).not.toHaveBeenCalled();
     });
 });

--- a/src/__tests__/useMirrordUi.test.ts
+++ b/src/__tests__/useMirrordUi.test.ts
@@ -2,6 +2,7 @@ import { renderHook, act, waitFor } from '@testing-library/react';
 import { useMirrordUi } from '../hooks/useMirrordUi';
 import type { OperatorSessionsResponse } from '../types';
 import { STORAGE_KEYS } from '../types';
+import { decodeConfig } from '../config';
 
 const owner = { username: 'alice', k8sUsername: 'alice@ex' };
 const createdAt = '2026-01-01T00:00:00Z';
@@ -105,6 +106,7 @@ beforeEach(() => {
             HeaderOperation: { SET: 'set' },
         },
         runtime: {
+            id: 'test-extension-id',
             getURL: (p: string) => `chrome-extension://test/${p}`,
             lastError: null,
         },
@@ -186,4 +188,72 @@ test('join writes the DNR rule and stores joined key', async () => {
         expect.objectContaining({ [STORAGE_KEYS.JOINED_KEY]: 'k1' }),
         expect.any(Function)
     );
+});
+
+test('session share builds an override config link without backend or join params', async () => {
+    const { result } = renderHook(() => useMirrordUi());
+    await waitFor(() =>
+        expect(result.current.sessions?.sessions.length).toBe(3)
+    );
+
+    const url = result.current.buildShareUrl('k1');
+    const payload = url.match(/[?&]payload=([^&]+)/)?.[1];
+
+    expect(url).toContain('/pages/config.html');
+    expect(url).toContain('&storage=override');
+    expect(url).not.toContain('/pages/configure.html');
+    expect(url).not.toContain('backend=');
+    expect(url).not.toContain('join=');
+    expect(payload).toBeTruthy();
+    expect(decodeConfig(payload!)).toEqual({
+        header_filter: 'baggage: mirrord-session=k1',
+    });
+});
+
+test('session share uses the operator HTTP filter when it can derive a header', async () => {
+    const responseWithFilter: OperatorSessionsResponse = {
+        ...sampleResponse,
+        sessions: sampleResponse.sessions.map((session) =>
+            session.key === 'k0'
+                ? {
+                      ...session,
+                      httpFilter: {
+                          headerFilter: '^x-tenant: alice$',
+                      },
+                  }
+                : session
+        ),
+    };
+    (global.fetch as jest.Mock).mockImplementation((url: RequestInfo | URL) => {
+        const makeResponse = (body: string, status = 200) =>
+            ({
+                ok: status >= 200 && status < 300,
+                status,
+                statusText: 'OK',
+                text: () => Promise.resolve(body),
+                json: () => Promise.resolve(JSON.parse(body)),
+            }) as unknown as Response;
+        if (String(url).includes('/api/operator-sessions')) {
+            return Promise.resolve(
+                makeResponse(JSON.stringify(responseWithFilter))
+            );
+        }
+        if (String(url).includes('/health')) {
+            return Promise.resolve(makeResponse('ok'));
+        }
+        return Promise.reject(new Error('unexpected fetch'));
+    });
+
+    const { result } = renderHook(() => useMirrordUi());
+    await waitFor(() =>
+        expect(result.current.sessions?.sessions.length).toBe(3)
+    );
+
+    const url = result.current.buildShareUrl('k0');
+    const payload = url.match(/[?&]payload=([^&]+)/)?.[1];
+
+    expect(payload).toBeTruthy();
+    expect(decodeConfig(payload!)).toEqual({
+        header_filter: 'x-tenant: alice',
+    });
 });

--- a/src/__tests__/util.test.ts
+++ b/src/__tests__/util.test.ts
@@ -4,6 +4,7 @@ import {
     buildDnrRule,
     encodeConfig,
     buildShareUrl,
+    sessionInjectionPair,
 } from '../util';
 import { decodeConfig } from '../config';
 import { STRINGS } from '../constants';
@@ -309,5 +310,41 @@ describe('buildShareUrl', () => {
         const url = buildShareUrl(config);
 
         expect(url).toContain('/pages/config.html');
+    });
+
+    it('can mark a config link as an override', () => {
+        const config = { header_filter: 'X-Test: value' };
+
+        const url = buildShareUrl(config, { storage: 'override' });
+
+        expect(url).toContain('?payload=');
+        expect(url).toContain('&storage=override');
+    });
+});
+
+describe('sessionInjectionPair', () => {
+    it('falls back to the baggage header when there is no http filter', () => {
+        expect(sessionInjectionPair({ key: 'k1' })).toEqual({
+            header: 'baggage',
+            value: 'mirrord-session=k1',
+        });
+    });
+
+    it('derives the pair from the session http filter when possible', () => {
+        expect(
+            sessionInjectionPair({
+                key: 'k1',
+                httpFilter: { headerFilter: '^x-tenant: alice$' },
+            })
+        ).toEqual({ header: 'x-tenant', value: 'alice' });
+    });
+
+    it('falls back to baggage when the filter cannot be derived', () => {
+        expect(
+            sessionInjectionPair({
+                key: 'k1',
+                httpFilter: { headerFilter: null },
+            })
+        ).toEqual({ header: 'baggage', value: 'mirrord-session=k1' });
     });
 });

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,19 +1,15 @@
 import { STORAGE_KEYS } from './types';
 import {
     buildDnrRule,
-    deriveInjectionHint,
     getDynamicRules,
     refreshIconIndicator,
+    sessionInjectionPair,
     storageGet,
     storageRemove,
     storageSet,
     updateDynamicRules,
 } from './util';
-import {
-    BAGGAGE_HEADER_NAME,
-    BAGGAGE_VALUE_PREFIX,
-    fetchOperatorSessions,
-} from './hooks/useMirrordUi';
+import { fetchOperatorSessions } from './hooks/useMirrordUi';
 import {
     HEADER_OBSERVATION_PORT,
     armCanary,
@@ -248,9 +244,7 @@ export async function handleJoin(key: string) {
             });
             return { type: JOIN_RESULT_TYPE, ok: false, error };
         }
-        const filterHint = deriveInjectionHint(target.httpFilter?.headerFilter);
-        const header = filterHint?.header ?? BAGGAGE_HEADER_NAME;
-        const value = filterHint?.value ?? `${BAGGAGE_VALUE_PREFIX}${key}`;
+        const { header, value } = sessionInjectionPair(target);
         const scope =
             (stored[STORAGE_KEYS.SCOPE_PATTERNS] as string[] | undefined) ?? [];
         const existing = await getDynamicRules();

--- a/src/components/SessionKeyGroup.tsx
+++ b/src/components/SessionKeyGroup.tsx
@@ -234,8 +234,8 @@ function GroupFooter({
                     type="button"
                     size="icon"
                     variant="ghost"
-                    aria-label={`Copy join link for ${groupKey}`}
-                    title="Copy join link"
+                    aria-label={`Copy override link for ${groupKey}`}
+                    title="Copy override link"
                     onClick={() => onShare(groupKey)}
                     style={{ height: 28, width: 28 }}
                 >

--- a/src/config.ts
+++ b/src/config.ts
@@ -38,7 +38,9 @@ export function isRegex(str: string): boolean {
  * @returns HTTP header key-value pair
  */
 export function parseHeader(header: string): { key: string; value: string } {
-    const [key, value] = header.split(':').map((s) => s.trim());
+    const separator = header.indexOf(':');
+    const key = separator === -1 ? '' : header.slice(0, separator).trim();
+    const value = separator === -1 ? '' : header.slice(separator + 1).trim();
     if (!key || !value) {
         emitUserBlocked('configure_invalid', 'user_action', {
             error: 'Invalid header format.',

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,11 +1,21 @@
 import '@metalbear/ui/styles.css';
-import { refreshIconIndicator } from './util';
+import {
+    buildDnrRule,
+    getDynamicRules,
+    refreshIconIndicator,
+    sessionInjectionPair,
+    storageGet,
+    storageSet,
+    updateDynamicRules,
+} from './util';
 import {
     Config,
     StoredConfig,
+    OperatorSessionSummary,
     STORAGE_KEYS,
     ALL_RESOURCE_TYPES,
 } from './types';
+import { fetchOperatorSessions } from './hooks/useMirrordUi';
 import { capture, emitUserBlocked, emitUserSucceeded } from './analytics';
 
 /**
@@ -67,23 +77,122 @@ export function storeDefaults(
     headerValue: string,
     scope?: string
 ): Promise<void> {
+    return storeHeaderConfig(
+        STORAGE_KEYS.DEFAULTS,
+        headerName,
+        headerValue,
+        scope
+    );
+}
+
+export function storeOverride(
+    headerName: string,
+    headerValue: string,
+    scope?: string
+): Promise<void> {
+    return storeHeaderConfig(
+        STORAGE_KEYS.OVERRIDE,
+        headerName,
+        headerValue,
+        scope
+    );
+}
+
+function storeHeaderConfig(
+    storageKey: typeof STORAGE_KEYS.DEFAULTS | typeof STORAGE_KEYS.OVERRIDE,
+    headerName: string,
+    headerValue: string,
+    scope?: string
+): Promise<void> {
     return new Promise((resolve) => {
-        const defaults: StoredConfig = {
+        const config: StoredConfig = {
             headerName,
             headerValue,
             scope,
         };
-        chrome.storage.local.set({ [STORAGE_KEYS.DEFAULTS]: defaults }, () => {
+        chrome.storage.local.set({ [storageKey]: config }, () => {
             if (chrome.runtime.lastError) {
                 console.error(
-                    'Failed to store defaults:',
+                    `Failed to store ${storageKey}:`,
                     chrome.runtime.lastError.message
                 );
             } else {
-                console.log('Defaults stored successfully.');
+                console.log(`${storageKey} stored successfully.`);
             }
             resolve();
         });
+    });
+}
+
+/**
+ * Look for a live operator session whose injection header matches the shared
+ * header, and join it (same storage/DNR shape as the popup join flow).
+ * @param headerName the HTTP header name from the shared link
+ * @param headerValue the HTTP header value from the shared link
+ * @returns the joined session key, or null when mirrord ui isn't configured
+ * or no live session matches — the caller then falls back to a manual rule
+ */
+export async function joinMatchingSession(
+    headerName: string,
+    headerValue: string
+): Promise<string | null> {
+    const stored = await storageGet([
+        STORAGE_KEYS.MIRRORD_UI_BACKEND,
+        STORAGE_KEYS.MIRRORD_UI_TOKEN,
+        STORAGE_KEYS.SCOPE_PATTERNS,
+    ]);
+    const backend = stored[STORAGE_KEYS.MIRRORD_UI_BACKEND] as
+        | string
+        | undefined;
+    const token = stored[STORAGE_KEYS.MIRRORD_UI_TOKEN] as string | undefined;
+    if (!backend || !token) return null;
+
+    let sessions: OperatorSessionSummary[];
+    try {
+        ({ sessions } = await fetchOperatorSessions(backend, token));
+    } catch {
+        return null;
+    }
+
+    const target = sessions.find((s) => {
+        const pair = sessionInjectionPair(s);
+        return (
+            pair.header.toLowerCase() === headerName.toLowerCase() &&
+            pair.value === headerValue
+        );
+    });
+    if (!target) return null;
+
+    const { header, value } = sessionInjectionPair(target);
+    const scope =
+        (stored[STORAGE_KEYS.SCOPE_PATTERNS] as string[] | undefined) ?? [];
+    const existing = await getDynamicRules();
+    await updateDynamicRules({
+        removeRuleIds: existing.map((r) => r.id),
+        addRules: buildDnrRule(header, value, scope),
+    });
+    await storageSet({
+        [STORAGE_KEYS.JOINED_KEY]: target.key,
+        [STORAGE_KEYS.JOINED_SESSION_NAME]: target.id,
+        [STORAGE_KEYS.JOINED_HEADER]: header,
+        [STORAGE_KEYS.JOINED_VALUE]: value,
+    });
+    refreshIconIndicator(1);
+    return target.key;
+}
+
+function clearJoinedSession(): Promise<void> {
+    return new Promise((resolve) => {
+        chrome.storage.local.remove(
+            [
+                STORAGE_KEYS.JOINED_KEY,
+                STORAGE_KEYS.JOINED_SESSION_NAME,
+                STORAGE_KEYS.JOINED_HEADER,
+                STORAGE_KEYS.JOINED_VALUE,
+                STORAGE_KEYS.SCOPE_PATTERNS,
+            ],
+            () => resolve()
+        );
     });
 }
 
@@ -114,7 +223,13 @@ export function promptForValidHeader(pattern: string): string {
     return header;
 }
 
-function setHeaderRule(header: string, scope?: string): Promise<void> {
+function setHeaderRule(
+    header: string,
+    scope?: string,
+    storageKey:
+        | typeof STORAGE_KEYS.DEFAULTS
+        | typeof STORAGE_KEYS.OVERRIDE = STORAGE_KEYS.DEFAULTS
+): Promise<void> {
     return new Promise((resolve, reject) => {
         let key: string, value: string;
 
@@ -181,10 +296,19 @@ function setHeaderRule(header: string, scope?: string): Promise<void> {
                         console.log('Header rule set successfully.');
                         refreshIconIndicator(rules.length);
 
-                        // Store defaults in chrome.storage
-                        storeDefaults(key.trim(), value.trim(), scope).then(
-                            resolve
-                        );
+                        const storeConfig =
+                            storageKey === STORAGE_KEYS.OVERRIDE
+                                ? storeOverride
+                                : storeDefaults;
+                        const clearSession =
+                            storageKey === STORAGE_KEYS.OVERRIDE
+                                ? clearJoinedSession()
+                                : Promise.resolve();
+                        clearSession
+                            .then(() =>
+                                storeConfig(key.trim(), value.trim(), scope)
+                            )
+                            .then(resolve);
                     }
                 }
             );
@@ -196,6 +320,10 @@ function setHeaderRule(header: string, scope?: string): Promise<void> {
 document.addEventListener('DOMContentLoaded', async () => {
     const params = new URLSearchParams(location.search);
     const encoded = params.get('payload');
+    const storageKey =
+        params.get('storage') === STORAGE_KEYS.OVERRIDE
+            ? STORAGE_KEYS.OVERRIDE
+            : STORAGE_KEYS.DEFAULTS;
 
     if (!encoded) {
         alert(
@@ -229,7 +357,21 @@ document.addEventListener('DOMContentLoaded', async () => {
     const scope = config.inject_scope;
 
     try {
-        await setHeaderRule(header, scope);
+        if (storageKey === STORAGE_KEYS.OVERRIDE) {
+            const { key, value } = parseHeader(header);
+            const joinedKey = await joinMatchingSession(key, value);
+            if (joinedKey) {
+                capture('extension_config_received', {
+                    is_regex: isRegex(config.header_filter),
+                    has_scope: !!scope,
+                    joined_session: true,
+                });
+                emitUserSucceeded('joined', 'user_action', { key: joinedKey });
+                alert(`Joined live session "${joinedKey}"!`);
+                return;
+            }
+        }
+        await setHeaderRule(header, scope, storageKey);
         const scopeMsg = scope ? ` (scope: ${scope})` : ' (all URLs)';
         capture('extension_config_received', {
             is_regex: isRegex(config.header_filter),

--- a/src/hooks/useMirrordUi.ts
+++ b/src/hooks/useMirrordUi.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import groupBy from 'lodash.groupby';
 import { STORAGE_KEYS } from '../types';
 import type {
+    Config,
     OperatorSessionSummary,
     OperatorSessionsResponse,
     OperatorWatchStatus,
@@ -14,8 +15,9 @@ import {
     storageRemove,
     getDynamicRules,
     updateDynamicRules,
-    deriveInjectionHint,
+    sessionInjectionPair,
     buildDnrRule,
+    buildShareUrl as buildConfigShareUrl,
 } from '../util';
 import { emitUserBlocked, emitUserSucceeded } from '../analytics';
 
@@ -91,9 +93,6 @@ export async function pingHealth(
         clearTimeout(timer);
     }
 }
-
-export const BAGGAGE_HEADER_NAME = 'baggage';
-export const BAGGAGE_VALUE_PREFIX = 'mirrord-session=';
 
 const OPERATOR_SESSIONS_POLL_MS = 5000;
 
@@ -294,11 +293,7 @@ export function useMirrordUi() {
                 setError(STRINGS.ERR_KEY_NOT_VISIBLE(key));
                 return;
             }
-            const filterHint = deriveInjectionHint(
-                target.httpFilter?.headerFilter
-            );
-            const header = filterHint?.header ?? BAGGAGE_HEADER_NAME;
-            const value = filterHint?.value ?? `${BAGGAGE_VALUE_PREFIX}${key}`;
+            const { header, value } = sessionInjectionPair(target);
             const existing = await getDynamicRules();
             await updateDynamicRules({
                 removeRuleIds: existing.map((r) => r.id),
@@ -377,13 +372,17 @@ export function useMirrordUi() {
 
     const buildShareUrl = useCallback(
         (key: string): string => {
-            const extUrl = chrome.runtime.getURL('pages/configure.html');
-            const u = new URL(extUrl);
-            u.searchParams.set('join', key);
-            if (backend) u.searchParams.set('backend', backend);
-            return u.toString();
+            const target = sessions?.sessions.find((s) => s.key === key);
+            const { header, value } = sessionInjectionPair({
+                key,
+                httpFilter: target?.httpFilter,
+            });
+            const config: Config = {
+                header_filter: `${header}: ${value}`,
+            };
+            return buildConfigShareUrl(config, { storage: 'override' });
         },
-        [backend]
+        [sessions]
     );
 
     return {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,7 +1,12 @@
 import RandExp from 'randexp';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
-import { Config, HeaderRule, ALL_RESOURCE_TYPES } from './types';
+import {
+    Config,
+    HeaderRule,
+    OperatorSessionSummary,
+    ALL_RESOURCE_TYPES,
+} from './types';
 import { STRINGS } from './constants';
 
 dayjs.extend(relativeTime);
@@ -161,9 +166,13 @@ export function encodeConfig(config: Config): string {
     return btoa(JSON.stringify(config));
 }
 
-export function buildShareUrl(config: Config): string {
+export function buildShareUrl(
+    config: Config,
+    options?: { storage?: 'override' }
+): string {
     const encoded = encodeConfig(config);
-    return `chrome-extension://${chrome.runtime.id}/pages/config.html?payload=${encoded}`;
+    const storageParam = options?.storage ? `&storage=${options.storage}` : '';
+    return `chrome-extension://${chrome.runtime.id}/pages/config.html?payload=${encoded}${storageParam}`;
 }
 
 export type InjectionHint = {
@@ -199,4 +208,18 @@ export function deriveInjectionHint(
     const generated = generateLowestMatch(trimmed);
     if (!generated) return null;
     return parseHeaderLine(generated);
+}
+
+export const BAGGAGE_HEADER_NAME = 'baggage';
+export const BAGGAGE_VALUE_PREFIX = 'mirrord-session=';
+
+export function sessionInjectionPair(
+    session: Pick<OperatorSessionSummary, 'key' | 'httpFilter'>
+): InjectionHint {
+    return (
+        deriveInjectionHint(session.httpFilter?.headerFilter) ?? {
+            header: BAGGAGE_HEADER_NAME,
+            value: `${BAGGAGE_VALUE_PREFIX}${session.key}`,
+        }
+    );
 }


### PR DESCRIPTION
feat(mirrord-browser): session share links use manual configure, join live session on receipt

This enables users not connected to the cluster or without mirrord ui open to be able to join the session.

The session share button now copies a config.html link carrying the session's header + value (marked storage=override) instead of the mirrord ui backend URL + key. When the extension processes such a link it first checks live operator sessions for one whose injection pair matches and joins it; otherwise it falls back to a manual override rule.

Factor the filter-hint-or-baggage derivation into sessionInjectionPair in util.ts, shared by the popup join, share, background join, and the new config-link matching.