### PR TITLE
fix: parseHeader keeps colons in header values

### DIFF
--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -65,6 +65,17 @@ describe('parseHeader', () => {
         expect(() => parseHeader('KeyOnly:')).toThrow();
         expect(() => parseHeader(':ValueOnly')).toThrow();
     });
+
+    it('keeps colons in the value (splits on the first colon only)', () => {
+        expect(parseHeader('X-Forwarded: host:8080')).toEqual({
+            key: 'X-Forwarded',
+            value: 'host:8080',
+        });
+        expect(parseHeader('baggage: mirrord-session=k1')).toEqual({
+            key: 'baggage',
+            value: 'mirrord-session=k1',
+        });
+    });
 });
 
 describe('decodeConfig', () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -38,7 +38,9 @@ export function isRegex(str: string): boolean {
  * @returns HTTP header key-value pair
  */
 export function parseHeader(header: string): { key: string; value: string } {
-    const [key, value] = header.split(':').map((s) => s.trim());
+    const separator = header.indexOf(':');
+    const key = separator === -1 ? '' : header.slice(0, separator).trim();
+    const value = separator === -1 ? '' : header.slice(separator + 1).trim();
     if (!key || !value) {
         emitUserBlocked('configure_invalid', 'user_action', {
             error: 'Invalid header format.',


### PR DESCRIPTION
## Summary

Suggested fix on top of #52 (targets the `sharelink` branch, not main).

`parseHeader` split on **every** colon and kept only the first two segments, so any header value containing a colon was silently truncated:

```
"X-Forwarded: host:8080"  ->  { key: "X-Forwarded", value: "host" }   // ":8080" lost
```

This matters for the new override share-link flow: the receiver parses a session's `header_filter` back through `parseHeader`, so a truncated value would fail the session match in `joinMatchingSession` and then install an override rule with the wrong value. Baggage links happen to be safe (no colon in the value), but HTTP-filter values aren't guaranteed to be.

Fix: split on the **first** colon only and keep the rest as the value. The empty key/value validation (and its `configure_invalid` analytics) is unchanged.

This is the only thing from a review of #52 that looked like a genuine bug rather than a by-design choice. Happy to drop it if you'd rather fold it into #52 directly.

## Test plan

- `pnpm test` — 163 passing, including a new `parseHeader` case for colon-containing and baggage values
- `pnpm run check` — prettier + eslint clean