### PR TITLE
ci: run e2e in the Playwright container with a job timeout

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,6 +59,9 @@ jobs:
         name: E2E Tests
         runs-on: ubuntu-latest
         needs: lint-and-format
+        timeout-minutes: 20
+        container:
+            image: mcr.microsoft.com/playwright:v1.58.1-jammy
 
         steps:
             - name: Checkout code
@@ -77,9 +80,6 @@ jobs:
 
             - name: Build extension
               run: pnpm build
-
-            - name: Install Playwright Chromium
-              run: pnpm exec playwright install chromium --with-deps
 
             - name: Run E2E tests
               run: xvfb-run pnpm test:e2e


### PR DESCRIPTION
## Summary

The e2e job has hung twice (e.g. run [27564303779](https://github.com/metalbear-co/mirrord-browser/actions/runs/27564303779)). The hang is in the **"Install Playwright Chromium"** step (`pnpm exec playwright install chromium --with-deps`), before any test runs: that step shells out to `apt` for system deps and intermittently blocks on the runner's apt lock / browser download. With no `timeout-minutes`, a hung step sat for ~35 min (and would run to the 6h default) instead of failing fast.

This is infra-level and not specific to any PR.

### Changes

- Run the `e2e` job in the official `mcr.microsoft.com/playwright:v1.58.1-jammy` image, which already ships the matching Chromium build and all system deps. This removes the `playwright install --with-deps` step entirely (the flake source). The tag matches the `@playwright/test` version in `package.json` and should be bumped alongside it.
- Add `timeout-minutes: 20` to the `e2e` job so any future hang fails fast and is retryable.

## Test plan

- [ ] CI e2e job goes green on this PR (no install step, runs in container).
- [ ] Confirm `xvfb-run pnpm test:e2e` still works inside the image (xvfb + browsers are bundled).