### PR TITLE
chore(release): 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mirrord-browser",
-    "version": "0.3.1",
+    "version": "0.4.0",
     "description": "Browser extension for mirrord",
     "type": "module",
     "scripts": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 3,
     "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAoasM13FWg9dB6ufOs6gHQKfExEmQkaXR7uVMRtJPvmLQB8EnivUNLGQ0b8OZ5Eggn21oXNgdEl7WhcKLuK20cHcW61TE7XAKIcV6uDmlc1FJFczxpqI7L+GgeeAtiC9vkHFulBHmfCxq4z8+zqNRLpwZ6xMyt6j9rJ7V1h7Uv0n4shf6xG0ukyTpfAc64Pkp4GtG+bdy51ki9XE0pJEnyotk5I9eGKp/3kL0EAQW0a9ES/5LM+fFwPU2EWZlqkx07zd1AnlzzQ4kz2rceBUIkI/x1mPyzNkPlnOtvlNUooFq8J5L3be2n1pZS099OM5ZLKKjomARcr/iiqgrjdkXAQIDAQAB",
     "name": "mirrord",
-    "version": "0.3.1",
+    "version": "0.4.0",
     "description": "More user-friendly testing with mirrord by automatically injecting HTTP header",
     "icons": {
         "48": "images/mirrord.png"
@@ -14,9 +14,14 @@
         "sidePanel"
     ],
     "incognito": "spanning",
-    "host_permissions": ["<all_urls>"],
+    "host_permissions": [
+        "<all_urls>"
+    ],
     "externally_connectable": {
-        "matches": ["http://localhost/*", "http://127.0.0.1/*"]
+        "matches": [
+            "http://localhost/*",
+            "http://127.0.0.1/*"
+        ]
     },
     "background": {
         "service_worker": "src/background.ts",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -14,14 +14,9 @@
         "sidePanel"
     ],
     "incognito": "spanning",
-    "host_permissions": [
-        "<all_urls>"
-    ],
+    "host_permissions": ["<all_urls>"],
     "externally_connectable": {
-        "matches": [
-            "http://localhost/*",
-            "http://127.0.0.1/*"
-        ]
+        "matches": ["http://localhost/*", "http://127.0.0.1/*"]
     },
     "background": {
         "service_worker": "src/background.ts",


### PR DESCRIPTION
## Summary

Bump `package.json` + `src/manifest.json` to **0.4.0** for the release that ships the session share links / join-live-session feature (#52). Minor bump since #52 is a user-facing feature.

Merging this does **not** publish. The Chrome Web Store publish + GitHub release is triggered by pushing the `v0.4.0` tag (per `release.yaml`, which validates the tag matches the version files). Once this merges, the tag can be pushed.

> Note: contains a second commit restoring prettier's inline array formatting in the manifest (a generated-bump artifact); squash-merge collapses it. Net diff is the two version lines only.

## Test plan

- [x] `release.yaml` version-match step will pass: tag `0.4.0` == `package.json` (`0.4.0`) == `src/manifest.json` (`0.4.0`).
- [ ] After merge: push `v0.4.0` → release pipeline builds, zips, uploads to Chrome Web Store, creates the GitHub release.