### PR TITLE
feat: land metalbear.com config links on an extension result page

### DIFF
--- a/pages/applied.html
+++ b/pages/applied.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html class="dark">
+    <head>
+        <meta charset="utf-8" />
+        <title>mirrord — Config Applied</title>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link
+            href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap"
+            rel="stylesheet"
+        />
+        <script type="module" src="../src/applied.tsx"></script>
+        <style>
+            html,
+            body {
+                margin: 0;
+                padding: 0;
+            }
+            body {
+                font-family: 'Poppins', system-ui, sans-serif;
+            }
+        </style>
+    </head>
+    <body class="bg-background text-foreground">
+        <div id="root"></div>
+    </body>
+</html>

--- a/src/__tests__/applied.test.tsx
+++ b/src/__tests__/applied.test.tsx
@@ -70,7 +70,7 @@ describe('applied result page run()', () => {
         }
     });
 
-    it('applies a valid payload and reports done', async () => {
+    it('applies a valid payload as a transient override (never defaults)', async () => {
         const payload = btoa(
             JSON.stringify({
                 header_filter: 'X-Test: v',
@@ -88,22 +88,26 @@ describe('applied result page run()', () => {
             scope: '*://example.com/*',
         });
         expect(mockUpdateDynamicRules).toHaveBeenCalled();
-        // default (non-override) links never try to join a session
-        expect(mockJoinMatchingSession).not.toHaveBeenCalled();
-        // default storage: persisted as defaults, no joined-session teardown
+        // every link first tries to join a matching live session
+        expect(mockJoinMatchingSession).toHaveBeenCalledWith('X-Test', 'v');
+        // persisted as a reset-able override, never the saved defaults
         expect(mockStorageSet).toHaveBeenCalledWith(
+            expect.objectContaining({ override: expect.anything() }),
+            expect.any(Function)
+        );
+        expect(mockStorageSet).not.toHaveBeenCalledWith(
             expect.objectContaining({ defaults: expect.anything() }),
             expect.any(Function)
         );
-        expect(mockStorageRemove).not.toHaveBeenCalled();
+        expect(mockStorageRemove).toHaveBeenCalled();
     });
 
-    it('joins a matching live session for an override link instead of a static rule', async () => {
+    it('joins a matching live session instead of writing a static rule', async () => {
         mockJoinMatchingSession.mockResolvedValue('k1');
         const payload = btoa(
             JSON.stringify({ header_filter: 'baggage: mirrord-session=k1' })
         );
-        setSearch(`?payload=${encodeURIComponent(payload)}&storage=override`);
+        setSearch(`?payload=${encodeURIComponent(payload)}`);
 
         const state = await run();
 
@@ -119,12 +123,12 @@ describe('applied result page run()', () => {
         );
     });
 
-    it('falls back to a static override when no live session matches', async () => {
+    it('falls back to a transient override when no live session matches', async () => {
         mockJoinMatchingSession.mockResolvedValue(null);
         const payload = btoa(
             JSON.stringify({ header_filter: 'baggage: mirrord-session=k1' })
         );
-        setSearch(`?payload=${encodeURIComponent(payload)}&storage=override`);
+        setSearch(`?payload=${encodeURIComponent(payload)}`);
 
         const state = await run();
 

--- a/src/__tests__/applied.test.tsx
+++ b/src/__tests__/applied.test.tsx
@@ -1,0 +1,140 @@
+/** @jest-environment jsdom */
+import React from 'react';
+
+// initTheme touches chrome.storage at module load; stub it so importing applied is safe.
+jest.mock('../theme', () => ({ initTheme: jest.fn() }));
+jest.mock('../analytics', () => ({
+    capture: jest.fn(),
+    emitUserBlocked: jest.fn(),
+    emitUserSucceeded: jest.fn(),
+}));
+jest.mock('@metalbear/ui', () => ({
+    Card: ({ children }: React.PropsWithChildren) => children,
+    CardContent: ({ children }: React.PropsWithChildren) => children,
+}));
+// joinMatchingSession's internals are covered by config.test; here we control its result to
+// exercise run()'s join-vs-static-override orchestration.
+jest.mock('../joinSession', () => ({ joinMatchingSession: jest.fn() }));
+
+import { run } from '../applied';
+import { joinMatchingSession } from '../joinSession';
+
+const mockJoinMatchingSession = joinMatchingSession as jest.Mock;
+const mockGetDynamicRules = jest.fn((cb: (rules: unknown[]) => void) => cb([]));
+const mockUpdateDynamicRules = jest.fn((_opts: unknown, cb: () => void) =>
+    cb()
+);
+const mockStorageSet = jest.fn((_data: unknown, cb: () => void) => cb());
+const mockStorageRemove = jest.fn((_keys: unknown, cb: () => void) => cb());
+
+beforeEach(() => {
+    mockJoinMatchingSession.mockReset();
+    mockJoinMatchingSession.mockResolvedValue(null);
+    mockGetDynamicRules.mockClear();
+    mockUpdateDynamicRules.mockClear();
+    mockStorageSet.mockClear();
+    mockStorageRemove.mockClear();
+    globalThis.chrome = {
+        storage: { local: { set: mockStorageSet, remove: mockStorageRemove } },
+        runtime: { lastError: null },
+        declarativeNetRequest: {
+            getDynamicRules: mockGetDynamicRules,
+            updateDynamicRules: mockUpdateDynamicRules,
+            RuleActionType: { MODIFY_HEADERS: 'modifyHeaders' },
+            HeaderOperation: { SET: 'set' },
+        },
+        action: { setBadgeText: jest.fn(), setBadgeTextColor: jest.fn() },
+    } as unknown as typeof chrome;
+});
+
+function setSearch(search: string): void {
+    window.history.replaceState({}, '', `/pages/applied.html${search}`);
+}
+
+describe('applied result page run()', () => {
+    it('errors when there is no payload', async () => {
+        setSearch('');
+        const state = await run();
+        expect(state).toEqual({
+            kind: 'error',
+            error: 'No config payload provided.',
+        });
+    });
+
+    it('errors on a malformed payload and echoes the invalid input', async () => {
+        setSearch('?payload=@@@not-base64@@@');
+        const state = await run();
+        expect(state.kind).toBe('error');
+        if (state.kind === 'error') {
+            expect(state.input).toBe('@@@not-base64@@@');
+        }
+    });
+
+    it('applies a valid payload and reports done', async () => {
+        const payload = btoa(
+            JSON.stringify({
+                header_filter: 'X-Test: v',
+                inject_scope: '*://example.com/*',
+            })
+        );
+        setSearch(`?payload=${encodeURIComponent(payload)}`);
+
+        const state = await run();
+
+        expect(state).toMatchObject({
+            kind: 'done',
+            header: 'X-Test',
+            value: 'v',
+            scope: '*://example.com/*',
+        });
+        expect(mockUpdateDynamicRules).toHaveBeenCalled();
+        // default (non-override) links never try to join a session
+        expect(mockJoinMatchingSession).not.toHaveBeenCalled();
+        // default storage: persisted as defaults, no joined-session teardown
+        expect(mockStorageSet).toHaveBeenCalledWith(
+            expect.objectContaining({ defaults: expect.anything() }),
+            expect.any(Function)
+        );
+        expect(mockStorageRemove).not.toHaveBeenCalled();
+    });
+
+    it('joins a matching live session for an override link instead of a static rule', async () => {
+        mockJoinMatchingSession.mockResolvedValue('k1');
+        const payload = btoa(
+            JSON.stringify({ header_filter: 'baggage: mirrord-session=k1' })
+        );
+        setSearch(`?payload=${encodeURIComponent(payload)}&storage=override`);
+
+        const state = await run();
+
+        expect(mockJoinMatchingSession).toHaveBeenCalledWith(
+            'baggage',
+            'mirrord-session=k1'
+        );
+        expect(state).toMatchObject({ kind: 'done', joinedKey: 'k1' });
+        // joined the live session — no static override written
+        expect(mockStorageSet).not.toHaveBeenCalledWith(
+            expect.objectContaining({ override: expect.anything() }),
+            expect.any(Function)
+        );
+    });
+
+    it('falls back to a static override when no live session matches', async () => {
+        mockJoinMatchingSession.mockResolvedValue(null);
+        const payload = btoa(
+            JSON.stringify({ header_filter: 'baggage: mirrord-session=k1' })
+        );
+        setSearch(`?payload=${encodeURIComponent(payload)}&storage=override`);
+
+        const state = await run();
+
+        expect(mockJoinMatchingSession).toHaveBeenCalled();
+        expect(state).toMatchObject({ kind: 'done' });
+        if (state.kind === 'done') expect(state.joinedKey).toBeUndefined();
+        expect(mockStorageSet).toHaveBeenCalledWith(
+            expect.objectContaining({ override: expect.anything() }),
+            expect.any(Function)
+        );
+        expect(mockStorageRemove).toHaveBeenCalled();
+    });
+});

--- a/src/__tests__/metalbearConfig.test.ts
+++ b/src/__tests__/metalbearConfig.test.ts
@@ -1,0 +1,47 @@
+import {
+    parseConfigPayload,
+    parseStorageOption,
+} from '../content/metalbearConfig';
+
+describe('parseConfigPayload', () => {
+    it('extracts the payload from a #config= hash', () => {
+        expect(parseConfigPayload('#config=abc123')).toBe('abc123');
+    });
+
+    it('requires a leading # (a bare query string is not a hash)', () => {
+        expect(parseConfigPayload('config=abc123')).toBeNull();
+    });
+
+    it('preserves base64 characters verbatim (no + -> space)', () => {
+        const payload = 'eyJhIjoiYiJ9+/==';
+        expect(parseConfigPayload(`#config=${payload}`)).toBe(payload);
+    });
+
+    it('reads config alongside other hash params', () => {
+        expect(parseConfigPayload('#foo=1&config=xyz&bar=2')).toBe('xyz');
+    });
+
+    it('returns null when there is no config param', () => {
+        expect(parseConfigPayload('#other=1')).toBeNull();
+        expect(parseConfigPayload('')).toBeNull();
+        expect(parseConfigPayload('#')).toBeNull();
+    });
+
+    it('returns null for an empty config value', () => {
+        expect(parseConfigPayload('#config=')).toBeNull();
+        expect(parseConfigPayload('#config=   ')).toBeNull();
+    });
+});
+
+describe('parseStorageOption', () => {
+    it('reads the storage option alongside the config payload', () => {
+        expect(parseStorageOption('#config=abc&storage=override')).toBe(
+            'override'
+        );
+    });
+
+    it('returns null when no storage param is present', () => {
+        expect(parseStorageOption('#config=abc')).toBeNull();
+        expect(parseStorageOption('')).toBeNull();
+    });
+});

--- a/src/__tests__/metalbearConfig.test.ts
+++ b/src/__tests__/metalbearConfig.test.ts
@@ -1,7 +1,4 @@
-import {
-    parseConfigPayload,
-    parseStorageOption,
-} from '../content/metalbearConfig';
+import { parseConfigPayload } from '../content/metalbearConfig';
 
 describe('parseConfigPayload', () => {
     it('extracts the payload from a #config= hash', () => {
@@ -31,17 +28,8 @@ describe('parseConfigPayload', () => {
         expect(parseConfigPayload('#config=')).toBeNull();
         expect(parseConfigPayload('#config=   ')).toBeNull();
     });
-});
 
-describe('parseStorageOption', () => {
-    it('reads the storage option alongside the config payload', () => {
-        expect(parseStorageOption('#config=abc&storage=override')).toBe(
-            'override'
-        );
-    });
-
-    it('returns null when no storage param is present', () => {
-        expect(parseStorageOption('#config=abc')).toBeNull();
-        expect(parseStorageOption('')).toBeNull();
+    it('ignores other hash params (config is the only one read)', () => {
+        expect(parseConfigPayload('#config=xyz&foo=bar')).toBe('xyz');
     });
 });

--- a/src/__tests__/useHeaderRules.test.ts
+++ b/src/__tests__/useHeaderRules.test.ts
@@ -605,7 +605,7 @@ describe('useHeaderRules analytics', () => {
             expect(mockClipboardWriteText).toHaveBeenCalledTimes(1);
             const url = mockClipboardWriteText.mock.calls[0][0];
             expect(url).toMatch(
-                /^chrome-extension:\/\/test-extension-id\/pages\/config\.html\?payload=/
+                /^https:\/\/metalbear\.com\/mirrord\/extension#config=/
             );
         });
 
@@ -653,7 +653,7 @@ describe('useHeaderRules analytics', () => {
             });
 
             const url = mockClipboardWriteText.mock.calls[0][0];
-            const payload = url.split('?payload=')[1];
+            const payload = url.split('#config=')[1];
             const decoded = JSON.parse(atob(payload));
             expect(decoded.inject_scope).toBe('*://example.com/*');
         });

--- a/src/__tests__/useMirrordUi.test.ts
+++ b/src/__tests__/useMirrordUi.test.ts
@@ -197,9 +197,9 @@ test('session share builds an override config link without backend or join param
     );
 
     const url = result.current.buildShareUrl('k1');
-    const payload = url.match(/[?&]payload=([^&]+)/)?.[1];
+    const payload = url.match(/#config=([^&]+)/)?.[1];
 
-    expect(url).toContain('/pages/config.html');
+    expect(url).toMatch(/^https:\/\/metalbear\.com\/mirrord\/extension#/);
     expect(url).toContain('&storage=override');
     expect(url).not.toContain('/pages/configure.html');
     expect(url).not.toContain('backend=');
@@ -250,7 +250,7 @@ test('session share uses the operator HTTP filter when it can derive a header', 
     );
 
     const url = result.current.buildShareUrl('k0');
-    const payload = url.match(/[?&]payload=([^&]+)/)?.[1];
+    const payload = url.match(/#config=([^&]+)/)?.[1];
 
     expect(payload).toBeTruthy();
     expect(decodeConfig(payload!)).toEqual({

--- a/src/__tests__/useMirrordUi.test.ts
+++ b/src/__tests__/useMirrordUi.test.ts
@@ -190,7 +190,7 @@ test('join writes the DNR rule and stores joined key', async () => {
     );
 });
 
-test('session share builds an override config link without backend or join params', async () => {
+test('session share builds a config link without backend or join params', async () => {
     const { result } = renderHook(() => useMirrordUi());
     await waitFor(() =>
         expect(result.current.sessions?.sessions.length).toBe(3)
@@ -200,7 +200,7 @@ test('session share builds an override config link without backend or join param
     const payload = url.match(/#config=([^&]+)/)?.[1];
 
     expect(url).toMatch(/^https:\/\/metalbear\.com\/mirrord\/extension#/);
-    expect(url).toContain('&storage=override');
+    expect(url).not.toContain('storage=');
     expect(url).not.toContain('/pages/configure.html');
     expect(url).not.toContain('backend=');
     expect(url).not.toContain('join=');

--- a/src/__tests__/util.test.ts
+++ b/src/__tests__/util.test.ts
@@ -288,13 +288,13 @@ describe('buildShareUrl', () => {
         expect(decoded).toEqual(config);
     });
 
-    it('can mark a config link as an override', () => {
+    it('carries no extra params (links are applied transiently, never persisted)', () => {
         const config = { header_filter: 'X-Test: value' };
 
-        const url = buildShareUrl(config, { storage: 'override' });
+        const url = buildShareUrl(config);
 
-        expect(url).toContain('#config=');
-        expect(url).toContain('&storage=override');
+        expect(url).not.toContain('&');
+        expect(url).not.toContain('storage=');
     });
 });
 

--- a/src/__tests__/util.test.ts
+++ b/src/__tests__/util.test.ts
@@ -258,37 +258,21 @@ describe('encodeConfig', () => {
 });
 
 describe('buildShareUrl', () => {
-    beforeEach(() => {
-        globalThis.chrome = {
-            ...globalThis.chrome,
-            runtime: {
-                id: 'test-extension-id',
-            },
-        } as any;
-    });
-
-    it('builds URL with chrome-extension:// prefix', () => {
+    it('points at the metalbear.com extension landing page', () => {
         const config = { header_filter: 'X-Test: value' };
 
         const url = buildShareUrl(config);
 
-        expect(url).toMatch(/^chrome-extension:\/\//);
+        expect(url).toMatch(/^https:\/\/metalbear\.com\/mirrord\/extension#/);
     });
 
-    it('includes extension ID in URL', () => {
+    it('carries the payload in the #config= hash', () => {
         const config = { header_filter: 'X-Test: value' };
 
         const url = buildShareUrl(config);
 
-        expect(url).toContain('test-extension-id');
-    });
-
-    it('includes payload query parameter', () => {
-        const config = { header_filter: 'X-Test: value' };
-
-        const url = buildShareUrl(config);
-
-        expect(url).toContain('?payload=');
+        expect(url).toContain('#config=');
+        expect(url).not.toContain('?payload=');
     });
 
     it('contains encoded config that can be decoded', () => {
@@ -298,18 +282,10 @@ describe('buildShareUrl', () => {
         };
 
         const url = buildShareUrl(config);
-        const payload = url.split('?payload=')[1];
+        const payload = url.split('#config=')[1];
         const decoded = decodeConfig(payload);
 
         expect(decoded).toEqual(config);
-    });
-
-    it('points to config.html page', () => {
-        const config = { header_filter: 'X-Test: value' };
-
-        const url = buildShareUrl(config);
-
-        expect(url).toContain('/pages/config.html');
     });
 
     it('can mark a config link as an override', () => {
@@ -317,7 +293,7 @@ describe('buildShareUrl', () => {
 
         const url = buildShareUrl(config, { storage: 'override' });
 
-        expect(url).toContain('?payload=');
+        expect(url).toContain('#config=');
         expect(url).toContain('&storage=override');
     });
 });

--- a/src/applied.tsx
+++ b/src/applied.tsx
@@ -17,7 +17,6 @@ import {
 } from './configCore';
 import { applyHeaderConfig } from './applyConfig';
 import { joinMatchingSession } from './joinSession';
-import { CONFIG_STORAGE_PARAM } from './constants';
 import { capture, emitUserBlocked, emitUserSucceeded } from './analytics';
 
 initTheme();
@@ -40,10 +39,6 @@ export async function run(): Promise<AppliedState> {
     if (!payload) {
         return { kind: 'error', error: 'No config payload provided.' };
     }
-    const storage =
-        params.get(CONFIG_STORAGE_PARAM) === 'override'
-            ? ('override' as const)
-            : undefined;
 
     let header: string;
     let value: string;
@@ -70,26 +65,24 @@ export async function run(): Promise<AppliedState> {
     }
 
     try {
-        // For an override (session-join) link, prefer joining a matching live operator session
-        // so traffic is actually routed — same precedence as the config.html handler. Only fall
-        // back to a static override rule when mirrord ui isn't up or no live session matches.
-        if (storage === 'override') {
-            const joinedKey = await joinMatchingSession(header, value);
-            if (joinedKey) {
-                capture('extension_config_received', {
-                    has_scope: !!scope,
-                    source: 'web_link',
-                    joined_session: true,
-                });
-                emitUserSucceeded('joined', 'user_action', {
-                    key: joinedKey,
-                    source: 'web_link',
-                });
-                return { kind: 'done', header, value, scope, joinedKey };
-            }
+        // Prefer joining a matching live operator session so traffic is actually routed. When
+        // none matches (mirrord ui not up, session ended), fall back to a transient override
+        // rule. Either way the link never overwrites the user's saved defaults.
+        const joinedKey = await joinMatchingSession(header, value);
+        if (joinedKey) {
+            capture('extension_config_received', {
+                has_scope: !!scope,
+                source: 'web_link',
+                joined_session: true,
+            });
+            emitUserSucceeded('joined', 'user_action', {
+                key: joinedKey,
+                source: 'web_link',
+            });
+            return { kind: 'done', header, value, scope, joinedKey };
         }
 
-        await applyHeaderConfig(header, value, scope, { storage });
+        await applyHeaderConfig(header, value, scope);
         capture('extension_config_received', {
             has_scope: !!scope,
             source: 'web_link',

--- a/src/applied.tsx
+++ b/src/applied.tsx
@@ -1,0 +1,216 @@
+// Result page the metalbear.com config link lands on. The content script navigates here (a
+// web-accessible extension page) with `?payload=<base64>`; this page decodes it, installs the
+// header rule (it runs as a privileged extension page, so it can call declarativeNetRequest),
+// and shows the outcome — so the user ends up on a real extension page, not the website.
+import { StrictMode, useEffect, useState } from 'react';
+import { createRoot } from 'react-dom/client';
+import { ErrorBoundary } from './components/ErrorBoundary';
+import '@metalbear/ui/styles.css';
+import './tokens.css';
+import { initTheme } from './theme';
+import { Card, CardContent } from '@metalbear/ui';
+import {
+    decodeConfig,
+    isRegex,
+    parseHeader,
+    promptForValidHeader,
+} from './configCore';
+import { applyHeaderConfig } from './applyConfig';
+import { joinMatchingSession } from './joinSession';
+import { CONFIG_STORAGE_PARAM } from './constants';
+import { capture, emitUserBlocked, emitUserSucceeded } from './analytics';
+
+initTheme();
+
+export type AppliedState =
+    | { kind: 'loading' }
+    | {
+          kind: 'done';
+          header: string;
+          value: string;
+          scope?: string;
+          joinedKey?: string;
+      }
+    | { kind: 'error'; error: string; input?: string };
+
+/** Decode the `?payload=` query, install the rule, and return the outcome. */
+export async function run(): Promise<AppliedState> {
+    const params = new URLSearchParams(window.location.search);
+    const payload = params.get('payload');
+    if (!payload) {
+        return { kind: 'error', error: 'No config payload provided.' };
+    }
+    const storage =
+        params.get(CONFIG_STORAGE_PARAM) === 'override'
+            ? ('override' as const)
+            : undefined;
+
+    let header: string;
+    let value: string;
+    let scope: string | undefined;
+    try {
+        const config = decodeConfig(payload);
+        if (!config.header_filter) {
+            throw new Error('Config is missing a header filter.');
+        }
+        const headerLine = isRegex(config.header_filter)
+            ? promptForValidHeader(config.header_filter)
+            : config.header_filter;
+        ({ key: header, value } = parseHeader(headerLine));
+        scope = config.inject_scope || undefined;
+    } catch (err) {
+        return {
+            kind: 'error',
+            error:
+                err instanceof Error
+                    ? err.message
+                    : 'The config link is malformed.',
+            input: payload,
+        };
+    }
+
+    try {
+        // For an override (session-join) link, prefer joining a matching live operator session
+        // so traffic is actually routed — same precedence as the config.html handler. Only fall
+        // back to a static override rule when mirrord ui isn't up or no live session matches.
+        if (storage === 'override') {
+            const joinedKey = await joinMatchingSession(header, value);
+            if (joinedKey) {
+                capture('extension_config_received', {
+                    has_scope: !!scope,
+                    source: 'web_link',
+                    joined_session: true,
+                });
+                emitUserSucceeded('joined', 'user_action', {
+                    key: joinedKey,
+                    source: 'web_link',
+                });
+                return { kind: 'done', header, value, scope, joinedKey };
+            }
+        }
+
+        await applyHeaderConfig(header, value, scope, { storage });
+        capture('extension_config_received', {
+            has_scope: !!scope,
+            source: 'web_link',
+        });
+        emitUserSucceeded('configured', 'user_action', { source: 'web_link' });
+        return { kind: 'done', header, value, scope };
+    } catch (err) {
+        const error = err instanceof Error ? err.message : String(err);
+        emitUserBlocked('configure_failed', 'user_action', {
+            error,
+            source: 'web_link',
+        });
+        return { kind: 'error', error };
+    }
+}
+
+function AppliedPage() {
+    const [state, setState] = useState<AppliedState>({ kind: 'loading' });
+
+    useEffect(() => {
+        run().then(setState);
+    }, []);
+
+    return (
+        <div style={{ maxWidth: 520, margin: '24px auto', padding: '0 16px' }}>
+            <Card>
+                <CardContent
+                    style={{
+                        padding: 24,
+                        display: 'flex',
+                        flexDirection: 'column',
+                        gap: 8,
+                    }}
+                >
+                    {state.kind === 'loading' && (
+                        <p className="text-sm text-muted-foreground">
+                            Applying mirrord config…
+                        </p>
+                    )}
+                    {state.kind === 'error' && (
+                        <>
+                            <h2 className="text-lg font-semibold">
+                                Couldn’t apply mirrord config
+                            </h2>
+                            <p className="text-sm text-muted-foreground">
+                                {state.error}
+                            </p>
+                            {state.input && (
+                                <>
+                                    <p className="text-meta text-muted-foreground">
+                                        Invalid input:
+                                    </p>
+                                    <pre
+                                        style={{
+                                            margin: 0,
+                                            padding: 12,
+                                            borderRadius: 6,
+                                            background: 'rgba(0, 0, 0, 0.06)',
+                                            fontFamily:
+                                                'ui-monospace, monospace',
+                                            fontSize: 12,
+                                            whiteSpace: 'pre-wrap',
+                                            wordBreak: 'break-all',
+                                            maxHeight: 160,
+                                            overflow: 'auto',
+                                        }}
+                                    >
+                                        {state.input}
+                                    </pre>
+                                </>
+                            )}
+                        </>
+                    )}
+                    {state.kind === 'done' && state.joinedKey && (
+                        <>
+                            <h2 className="text-lg font-semibold">
+                                Joined live session
+                            </h2>
+                            <p className="text-sm text-muted-foreground">
+                                Routing your traffic to session{' '}
+                                <code className="font-mono bg-muted px-1 py-0.5 rounded">
+                                    {state.joinedKey}
+                                </code>{' '}
+                                by injecting{' '}
+                                <code className="font-mono bg-muted px-1 py-0.5 rounded">
+                                    {state.header}: {state.value}
+                                </code>
+                                .
+                            </p>
+                        </>
+                    )}
+                    {state.kind === 'done' && !state.joinedKey && (
+                        <>
+                            <h2 className="text-lg font-semibold">
+                                mirrord header configured
+                            </h2>
+                            <p className="text-sm text-muted-foreground">
+                                Injecting{' '}
+                                <code className="font-mono bg-muted px-1 py-0.5 rounded">
+                                    {state.header}: {state.value}
+                                </code>{' '}
+                                {state.scope
+                                    ? `on requests matching ${state.scope}.`
+                                    : 'on all requests.'}
+                            </p>
+                        </>
+                    )}
+                </CardContent>
+            </Card>
+        </div>
+    );
+}
+
+const container = document.getElementById('root');
+if (container) {
+    const root = createRoot(container);
+    root.render(
+        <StrictMode>
+            <ErrorBoundary flow="header_injector" component="applied">
+                <AppliedPage />
+            </ErrorBoundary>
+        </StrictMode>
+    );
+}

--- a/src/applyConfig.ts
+++ b/src/applyConfig.ts
@@ -1,6 +1,8 @@
-// Install a header-injection DNR rule and persist it as the stored default. Used by the
+// Install a header-injection DNR rule and persist it as a transient override. Used by the
 // metalbear.com result page (applied.tsx), which runs as a privileged extension page and so
-// can call declarativeNetRequest directly.
+// can call declarativeNetRequest directly. Incoming config links are never written to the
+// user's saved defaults — they apply as a reset-able override (or, when a live session matches,
+// the caller joins it instead). The user's defaults are only ever set locally in the popup.
 import {
     buildDnrRule,
     getDynamicRules,
@@ -14,8 +16,7 @@ import { STORAGE_KEYS } from './types';
 export async function applyHeaderConfig(
     header: string,
     value: string,
-    scope?: string,
-    options?: { storage?: 'override' }
+    scope?: string
 ): Promise<void> {
     const existing = await getDynamicRules();
     const rules = buildDnrRule(header, value, scope);
@@ -26,21 +27,21 @@ export async function applyHeaderConfig(
         ],
         addRules: rules,
     });
-    const config = { headerName: header, headerValue: value, scope };
-    if (options?.storage === 'override') {
-        // Temporary override (e.g. a shared session-join link): replace any joined-session
-        // state and store under OVERRIDE so the user's saved defaults stay intact and can be
-        // restored with reset-to-defaults — mirrors the config.html `storage=override` path.
-        await storageRemove([
-            STORAGE_KEYS.JOINED_KEY,
-            STORAGE_KEYS.JOINED_SESSION_NAME,
-            STORAGE_KEYS.JOINED_HEADER,
-            STORAGE_KEYS.JOINED_VALUE,
-            STORAGE_KEYS.SCOPE_PATTERNS,
-        ]);
-        await storageSet({ [STORAGE_KEYS.OVERRIDE]: config });
-    } else {
-        await storageSet({ [STORAGE_KEYS.DEFAULTS]: config });
-    }
+    // Replace any joined-session state and store under OVERRIDE so the user's saved defaults
+    // stay intact and can be restored with reset-to-defaults.
+    await storageRemove([
+        STORAGE_KEYS.JOINED_KEY,
+        STORAGE_KEYS.JOINED_SESSION_NAME,
+        STORAGE_KEYS.JOINED_HEADER,
+        STORAGE_KEYS.JOINED_VALUE,
+        STORAGE_KEYS.SCOPE_PATTERNS,
+    ]);
+    await storageSet({
+        [STORAGE_KEYS.OVERRIDE]: {
+            headerName: header,
+            headerValue: value,
+            scope,
+        },
+    });
     refreshIconIndicator(rules.length);
 }

--- a/src/applyConfig.ts
+++ b/src/applyConfig.ts
@@ -1,0 +1,46 @@
+// Install a header-injection DNR rule and persist it as the stored default. Used by the
+// metalbear.com result page (applied.tsx), which runs as a privileged extension page and so
+// can call declarativeNetRequest directly.
+import {
+    buildDnrRule,
+    getDynamicRules,
+    refreshIconIndicator,
+    storageRemove,
+    storageSet,
+    updateDynamicRules,
+} from './util';
+import { STORAGE_KEYS } from './types';
+
+export async function applyHeaderConfig(
+    header: string,
+    value: string,
+    scope?: string,
+    options?: { storage?: 'override' }
+): Promise<void> {
+    const existing = await getDynamicRules();
+    const rules = buildDnrRule(header, value, scope);
+    await updateDynamicRules({
+        removeRuleIds: [
+            ...rules.map((r) => r.id),
+            ...existing.map((r) => r.id),
+        ],
+        addRules: rules,
+    });
+    const config = { headerName: header, headerValue: value, scope };
+    if (options?.storage === 'override') {
+        // Temporary override (e.g. a shared session-join link): replace any joined-session
+        // state and store under OVERRIDE so the user's saved defaults stay intact and can be
+        // restored with reset-to-defaults — mirrors the config.html `storage=override` path.
+        await storageRemove([
+            STORAGE_KEYS.JOINED_KEY,
+            STORAGE_KEYS.JOINED_SESSION_NAME,
+            STORAGE_KEYS.JOINED_HEADER,
+            STORAGE_KEYS.JOINED_VALUE,
+            STORAGE_KEYS.SCOPE_PATTERNS,
+        ]);
+        await storageSet({ [STORAGE_KEYS.OVERRIDE]: config });
+    } else {
+        await storageSet({ [STORAGE_KEYS.DEFAULTS]: config });
+    }
+    refreshIconIndicator(rules.length);
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,71 +1,23 @@
 import '@metalbear/ui/styles.css';
-import {
-    buildDnrRule,
-    getDynamicRules,
-    refreshIconIndicator,
-    sessionInjectionPair,
-    storageGet,
-    storageSet,
-    updateDynamicRules,
-} from './util';
+import { refreshIconIndicator } from './util';
 import {
     Config,
     StoredConfig,
-    OperatorSessionSummary,
     STORAGE_KEYS,
     ALL_RESOURCE_TYPES,
 } from './types';
-import { fetchOperatorSessions } from './hooks/useMirrordUi';
 import { capture, emitUserBlocked, emitUserSucceeded } from './analytics';
+import {
+    isRegex,
+    parseHeader,
+    decodeConfig,
+    promptForValidHeader,
+} from './configCore';
+import { joinMatchingSession } from './joinSession';
 
-/**
- * Check if the input string is a regex or an explicit HTTP header.
- * @param str a string value that's either a regex or an explicit HTTP header
- * @returns
- */
-export function isRegex(str: string): boolean {
-    const regexIndicators = [
-        /\\[dDsSwWbB]/, // escaped shorthand classes
-        /\\./, // escaped dot
-        /[.*+?^${}()|[\]]/, // unescaped special characters
-    ];
-    return regexIndicators.some((pattern) => pattern.test(str));
-}
-
-/**
- * Prase the input string value and return an HTTP header key-value pair.
- * @param header a string value to be parsed as HTTP header key and value
- * @returns HTTP header key-value pair
- */
-export function parseHeader(header: string): { key: string; value: string } {
-    const separator = header.indexOf(':');
-    const key = separator === -1 ? '' : header.slice(0, separator).trim();
-    const value = separator === -1 ? '' : header.slice(separator + 1).trim();
-    if (!key || !value) {
-        emitUserBlocked('configure_invalid', 'user_action', {
-            error: 'Invalid header format.',
-        });
-        throw new Error('Invalid header format.');
-    }
-    return { key, value };
-}
-
-/**
- * Decode the given string into a configuration object.
- * @param encoded a base64 encoded string configuration payload
- * @returns deserialized configuration object
- */
-export function decodeConfig(encoded: string): Config {
-    const decoded = atob(encoded);
-    try {
-        return JSON.parse(decoded) as Config;
-    } catch (error) {
-        emitUserBlocked('configure_invalid', 'user_action', {
-            error: 'Invalid configuration',
-        });
-        throw new Error('Invalid configuration');
-    }
-}
+// Re-exported so existing importers (and tests) keep using `./config`.
+export { isRegex, parseHeader, decodeConfig, promptForValidHeader };
+export { joinMatchingSession };
 
 /**
  * Store the given header configuration as defaults in chrome.storage.local.
@@ -126,63 +78,6 @@ function storeHeaderConfig(
     });
 }
 
-/**
- * Look for a live operator session whose injection header matches the shared
- * header, and join it (same storage/DNR shape as the popup join flow).
- * @param headerName the HTTP header name from the shared link
- * @param headerValue the HTTP header value from the shared link
- * @returns the joined session key, or null when mirrord ui isn't configured
- * or no live session matches — the caller then falls back to a manual rule
- */
-export async function joinMatchingSession(
-    headerName: string,
-    headerValue: string
-): Promise<string | null> {
-    const stored = await storageGet([
-        STORAGE_KEYS.MIRRORD_UI_BACKEND,
-        STORAGE_KEYS.MIRRORD_UI_TOKEN,
-        STORAGE_KEYS.SCOPE_PATTERNS,
-    ]);
-    const backend = stored[STORAGE_KEYS.MIRRORD_UI_BACKEND] as
-        | string
-        | undefined;
-    const token = stored[STORAGE_KEYS.MIRRORD_UI_TOKEN] as string | undefined;
-    if (!backend || !token) return null;
-
-    let sessions: OperatorSessionSummary[];
-    try {
-        ({ sessions } = await fetchOperatorSessions(backend, token));
-    } catch {
-        return null;
-    }
-
-    const target = sessions.find((s) => {
-        const pair = sessionInjectionPair(s);
-        return (
-            pair.header.toLowerCase() === headerName.toLowerCase() &&
-            pair.value === headerValue
-        );
-    });
-    if (!target) return null;
-
-    const { header, value } = sessionInjectionPair(target);
-    const scope =
-        (stored[STORAGE_KEYS.SCOPE_PATTERNS] as string[] | undefined) ?? [];
-    const existing = await getDynamicRules();
-    await updateDynamicRules({
-        removeRuleIds: existing.map((r) => r.id),
-        addRules: buildDnrRule(header, value, scope),
-    });
-    await storageSet({
-        [STORAGE_KEYS.JOINED_KEY]: target.key,
-        [STORAGE_KEYS.JOINED_SESSION_NAME]: target.id,
-        [STORAGE_KEYS.JOINED_HEADER]: header,
-        [STORAGE_KEYS.JOINED_VALUE]: value,
-    });
-    refreshIconIndicator(1);
-    return target.key;
-}
-
 function clearJoinedSession(): Promise<void> {
     return new Promise((resolve) => {
         chrome.storage.local.remove(
@@ -196,33 +91,6 @@ function clearJoinedSession(): Promise<void> {
             () => resolve()
         );
     });
-}
-
-/**
- * Prompt the user for an HTTP header value that matches the given pattern.
- * @param pattern a regex pattern for HTTP headers
- * @returns
- */
-export function promptForValidHeader(pattern: string): string {
-    const regex = new RegExp(pattern);
-    let header: string | null = null;
-
-    while (!header) {
-        const input = prompt(
-            `Enter a header that matches pattern:\n${pattern}`
-        );
-        if (!input) {
-            alert('No input provided.');
-            continue;
-        }
-        if (!regex.test(input)) {
-            alert('Input does not match the required pattern.');
-            continue;
-        }
-        header = input;
-    }
-
-    return header;
 }
 
 function setHeaderRule(

--- a/src/configCore.ts
+++ b/src/configCore.ts
@@ -1,0 +1,88 @@
+// Pure config-payload helpers shared by the in-extension config page (config.ts) and the
+// metalbear.com content script. Kept free of module-level side effects so it can be imported
+// into a content script without dragging in config.ts's page bootstrap (which would alert on
+// any page that lacks a `?payload=`).
+import { Config } from './types';
+import { emitUserBlocked } from './analytics';
+
+/**
+ * Check if the input string is a regex or an explicit HTTP header.
+ * @param str a string value that's either a regex or an explicit HTTP header
+ */
+export function isRegex(str: string): boolean {
+    const regexIndicators = [
+        /\\[dDsSwWbB]/, // escaped shorthand classes
+        /\\./, // escaped dot
+        /[.*+?^${}()|[\]]/, // unescaped special characters
+    ];
+    return regexIndicators.some((pattern) => pattern.test(str));
+}
+
+/**
+ * Parse the input string value and return an HTTP header key-value pair.
+ * @param header a string value to be parsed as HTTP header key and value
+ */
+export function parseHeader(header: string): { key: string; value: string } {
+    // Split on the first colon only so header values may themselves contain colons
+    // (e.g. `X-Forwarded: host:8080`, `baggage: mirrord-session=k1`).
+    const separator = header.indexOf(':');
+    const key = separator === -1 ? '' : header.slice(0, separator).trim();
+    const value = separator === -1 ? '' : header.slice(separator + 1).trim();
+    if (!key || !value) {
+        emitUserBlocked('configure_invalid', 'user_action', {
+            error: 'Invalid header format.',
+        });
+        throw new Error('Invalid header format.');
+    }
+    return { key, value };
+}
+
+/**
+ * Decode the given base64 string into a configuration object. Throws on malformed input.
+ * @param encoded a base64 encoded string configuration payload
+ */
+export function decodeConfig(encoded: string): Config {
+    let decoded: string;
+    try {
+        decoded = atob(encoded);
+    } catch {
+        emitUserBlocked('configure_invalid', 'user_action', {
+            error: 'Invalid configuration',
+        });
+        throw new Error('Invalid configuration');
+    }
+    try {
+        return JSON.parse(decoded) as Config;
+    } catch {
+        emitUserBlocked('configure_invalid', 'user_action', {
+            error: 'Invalid configuration',
+        });
+        throw new Error('Invalid configuration');
+    }
+}
+
+/**
+ * Prompt the user for an HTTP header value that matches the given pattern.
+ * @param pattern a regex pattern for HTTP headers
+ */
+export function promptForValidHeader(pattern: string): string {
+    const regex = new RegExp(pattern);
+    let header: string | null = null;
+
+    while (!header) {
+        const input = prompt(
+            `Enter a header that matches pattern:\n${pattern}`
+        );
+        if (!input) {
+            alert('No input provided.');
+            continue;
+        }
+        if (!regex.test(input)) {
+            alert('Input does not match the required pattern.');
+            continue;
+        }
+        header = input;
+    }
+
+    return header;
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -131,6 +131,20 @@ export type RowTag = (typeof ROW_TAG)[keyof typeof ROW_TAG];
 
 export const NAMESPACE_ALL_SENTINEL = '__all__';
 
+// The metalbear.com page whose visits the content script intercepts. Share links point here
+// (with a `#config=` payload) rather than at a `chrome-extension://` URL, so recipients without
+// the extension land on the install page, and once installed the content script applies the
+// payload on a privileged extension page.
+export const METALBEAR_EXTENSION_URL =
+    'https://metalbear.com/mirrord/extension';
+
+// The hash parameter on metalbear.com/mirrord/extension that carries the config payload.
+export const CONFIG_HASH_PARAM = 'config';
+
+// Hash/query parameter selecting the storage slot. 'override' stores a temporary session
+// override (cleared on reset-to-defaults) instead of overwriting the saved defaults.
+export const CONFIG_STORAGE_PARAM = 'storage';
+
 export const CONFIGURE_STATUS = {
     LOADING: 'loading',
     CONNECTED: 'connected',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -139,11 +139,9 @@ export const METALBEAR_EXTENSION_URL =
     'https://metalbear.com/mirrord/extension';
 
 // The hash parameter on metalbear.com/mirrord/extension that carries the config payload.
+// Links are always applied transiently (joined live session, or a reset-able override) and
+// never overwrite the user's saved defaults, so no separate storage-slot param is needed.
 export const CONFIG_HASH_PARAM = 'config';
-
-// Hash/query parameter selecting the storage slot. 'override' stores a temporary session
-// override (cleared on reset-to-defaults) instead of overwriting the saved defaults.
-export const CONFIG_STORAGE_PARAM = 'storage';
 
 export const CONFIGURE_STATUS = {
     LOADING: 'loading',

--- a/src/content/metalbearConfig.ts
+++ b/src/content/metalbearConfig.ts
@@ -5,37 +5,27 @@
 // (pages/applied.html), which decodes it, installs the rule, and shows the outcome — so the
 // user lands on an extension page instead of staying on the website. A bare visit (no
 // `#config=`) just gets a small in-page note and is otherwise left alone.
-import { CONFIG_HASH_PARAM, CONFIG_STORAGE_PARAM } from '../constants';
+import { CONFIG_HASH_PARAM } from '../constants';
 
 /**
- * Read a named parameter from a URL hash like `#config=PAYLOAD&storage=override`. Expects the
- * raw `window.location.hash`, which is always either empty or `#`-prefixed; anything else
- * returns null. The value is taken verbatim (not via URLSearchParams) so a base64 payload
- * keeps its `+`/`/`/`=` characters intact; it is re-encoded with encodeURIComponent when
- * building the result-page URL.
+ * Extract the config payload from a `#config=PAYLOAD` hash. Expects the raw
+ * `window.location.hash`, which is always either empty or `#`-prefixed; anything else returns
+ * null. The value is taken verbatim (not via URLSearchParams) so a base64 payload keeps its
+ * `+`/`/`/`=` characters intact; it is re-encoded with encodeURIComponent when building the
+ * result-page URL.
  */
-function readHashParam(hash: string, name: string): string | null {
+export function parseConfigPayload(hash: string): string | null {
     if (!hash.startsWith('#')) return null;
     const raw = hash.slice(1);
     if (!raw) return null;
     for (const part of raw.split('&')) {
         const eq = part.indexOf('=');
         if (eq === -1) continue;
-        if (part.slice(0, eq) !== name) continue;
+        if (part.slice(0, eq) !== CONFIG_HASH_PARAM) continue;
         const value = part.slice(eq + 1);
         return value.trim().length > 0 ? value : null;
     }
     return null;
-}
-
-/** Extract the config payload from a `#config=PAYLOAD` hash. */
-export function parseConfigPayload(hash: string): string | null {
-    return readHashParam(hash, CONFIG_HASH_PARAM);
-}
-
-/** Extract the optional `storage` option (e.g. `override`) from the hash. */
-export function parseStorageOption(hash: string): string | null {
-    return readHashParam(hash, CONFIG_STORAGE_PARAM);
 }
 
 const MESSAGE_BOX_ID = 'mirrord-config-message';
@@ -92,9 +82,7 @@ function handleHash(): void {
         return;
     }
 
-    const storage = parseStorageOption(window.location.hash);
     const params = new URLSearchParams({ payload });
-    if (storage) params.set(CONFIG_STORAGE_PARAM, storage);
     const url = `${chrome.runtime.getURL('pages/applied.html')}?${params.toString()}`;
     window.location.replace(url);
 }

--- a/src/content/metalbearConfig.ts
+++ b/src/content/metalbearConfig.ts
@@ -1,0 +1,103 @@
+// Content script for metalbear.com/mirrord/extension. Links of the form
+//   https://metalbear.com/mirrord/extension#config=<payload>
+// carry the same base64 config payload that the in-extension config page accepts. When a
+// payload is present we redirect the tab to our own web-accessible result page
+// (pages/applied.html), which decodes it, installs the rule, and shows the outcome — so the
+// user lands on an extension page instead of staying on the website. A bare visit (no
+// `#config=`) just gets a small in-page note and is otherwise left alone.
+import { CONFIG_HASH_PARAM, CONFIG_STORAGE_PARAM } from '../constants';
+
+/**
+ * Read a named parameter from a URL hash like `#config=PAYLOAD&storage=override`. Expects the
+ * raw `window.location.hash`, which is always either empty or `#`-prefixed; anything else
+ * returns null. The value is taken verbatim (not via URLSearchParams) so a base64 payload
+ * keeps its `+`/`/`/`=` characters intact; it is re-encoded with encodeURIComponent when
+ * building the result-page URL.
+ */
+function readHashParam(hash: string, name: string): string | null {
+    if (!hash.startsWith('#')) return null;
+    const raw = hash.slice(1);
+    if (!raw) return null;
+    for (const part of raw.split('&')) {
+        const eq = part.indexOf('=');
+        if (eq === -1) continue;
+        if (part.slice(0, eq) !== name) continue;
+        const value = part.slice(eq + 1);
+        return value.trim().length > 0 ? value : null;
+    }
+    return null;
+}
+
+/** Extract the config payload from a `#config=PAYLOAD` hash. */
+export function parseConfigPayload(hash: string): string | null {
+    return readHashParam(hash, CONFIG_HASH_PARAM);
+}
+
+/** Extract the optional `storage` option (e.g. `override`) from the hash. */
+export function parseStorageOption(hash: string): string | null {
+    return readHashParam(hash, CONFIG_STORAGE_PARAM);
+}
+
+const MESSAGE_BOX_ID = 'mirrord-config-message';
+
+/** Render a small fixed note in the page (used only for the "no config" case). */
+function showMessage(title: string, detail: string): void {
+    const parent = document.body ?? document.documentElement;
+    if (!parent || document.getElementById(MESSAGE_BOX_ID)) return;
+
+    const box = document.createElement('div');
+    box.id = MESSAGE_BOX_ID;
+    Object.assign(box.style, {
+        position: 'fixed',
+        top: '16px',
+        right: '16px',
+        zIndex: '2147483647',
+        maxWidth: '320px',
+        padding: '12px 14px',
+        borderRadius: '8px',
+        background: '#ffffff',
+        color: '#111827',
+        boxShadow: '0 6px 24px rgba(0, 0, 0, 0.18)',
+        borderLeft: '4px solid #756df3',
+        font: '13px/1.4 system-ui, -apple-system, sans-serif',
+    });
+
+    const titleEl = document.createElement('div');
+    titleEl.style.fontWeight = '600';
+    titleEl.textContent = `mirrord — ${title}`;
+    box.appendChild(titleEl);
+
+    const detailEl = document.createElement('div');
+    Object.assign(detailEl.style, { marginTop: '4px', color: '#4b5563' });
+    detailEl.textContent = detail;
+    box.appendChild(detailEl);
+
+    parent.appendChild(box);
+}
+
+// Sentinel distinct from `null` (= "no config") so the first run still notes an empty link,
+// while repeated hashchange events with the same value don't redirect twice.
+let lastPayload: string | null | undefined = undefined;
+
+function handleHash(): void {
+    const payload = parseConfigPayload(window.location.hash);
+    if (payload === lastPayload) return;
+    lastPayload = payload;
+
+    if (!payload) {
+        showMessage(
+            'No config found',
+            'This link has no “#config=…” payload to apply.'
+        );
+        return;
+    }
+
+    const storage = parseStorageOption(window.location.hash);
+    const params = new URLSearchParams({ payload });
+    if (storage) params.set(CONFIG_STORAGE_PARAM, storage);
+    const url = `${chrome.runtime.getURL('pages/applied.html')}?${params.toString()}`;
+    window.location.replace(url);
+}
+
+handleHash();
+window.addEventListener('hashchange', handleHash);

--- a/src/hooks/useMirrordUi.ts
+++ b/src/hooks/useMirrordUi.ts
@@ -380,7 +380,7 @@ export function useMirrordUi() {
             const config: Config = {
                 header_filter: `${header}: ${value}`,
             };
-            return buildConfigShareUrl(config, { storage: 'override' });
+            return buildConfigShareUrl(config);
         },
         [sessions]
     );

--- a/src/joinSession.ts
+++ b/src/joinSession.ts
@@ -1,0 +1,71 @@
+// Shared session-join logic, kept free of module-level side effects so it can be imported by
+// both the config-link handler (config.ts) and the metalbear.com result page (applied.tsx)
+// without dragging in either page's DOM bootstrap.
+import {
+    buildDnrRule,
+    getDynamicRules,
+    refreshIconIndicator,
+    sessionInjectionPair,
+    storageGet,
+    storageSet,
+    updateDynamicRules,
+} from './util';
+import { OperatorSessionSummary, STORAGE_KEYS } from './types';
+import { fetchOperatorSessions } from './hooks/useMirrordUi';
+
+/**
+ * Look for a live operator session whose injection header matches the shared
+ * header, and join it (same storage/DNR shape as the popup join flow).
+ * @param headerName the HTTP header name from the shared link
+ * @param headerValue the HTTP header value from the shared link
+ * @returns the joined session key, or null when mirrord ui isn't configured
+ * or no live session matches — the caller then falls back to a manual rule
+ */
+export async function joinMatchingSession(
+    headerName: string,
+    headerValue: string
+): Promise<string | null> {
+    const stored = await storageGet([
+        STORAGE_KEYS.MIRRORD_UI_BACKEND,
+        STORAGE_KEYS.MIRRORD_UI_TOKEN,
+        STORAGE_KEYS.SCOPE_PATTERNS,
+    ]);
+    const backend = stored[STORAGE_KEYS.MIRRORD_UI_BACKEND] as
+        | string
+        | undefined;
+    const token = stored[STORAGE_KEYS.MIRRORD_UI_TOKEN] as string | undefined;
+    if (!backend || !token) return null;
+
+    let sessions: OperatorSessionSummary[];
+    try {
+        ({ sessions } = await fetchOperatorSessions(backend, token));
+    } catch {
+        return null;
+    }
+
+    const target = sessions.find((s) => {
+        const pair = sessionInjectionPair(s);
+        return (
+            pair.header.toLowerCase() === headerName.toLowerCase() &&
+            pair.value === headerValue
+        );
+    });
+    if (!target) return null;
+
+    const { header, value } = sessionInjectionPair(target);
+    const scope =
+        (stored[STORAGE_KEYS.SCOPE_PATTERNS] as string[] | undefined) ?? [];
+    const existing = await getDynamicRules();
+    await updateDynamicRules({
+        removeRuleIds: existing.map((r) => r.id),
+        addRules: buildDnrRule(header, value, scope),
+    });
+    await storageSet({
+        [STORAGE_KEYS.JOINED_KEY]: target.key,
+        [STORAGE_KEYS.JOINED_SESSION_NAME]: target.id,
+        [STORAGE_KEYS.JOINED_HEADER]: header,
+        [STORAGE_KEYS.JOINED_VALUE]: value,
+    });
+    refreshIconIndicator(1);
+    return target.key;
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -26,5 +26,24 @@
     "side_panel": {
         "default_path": "pages/popup.html"
     },
-    "options_page": "pages/options.html"
+    "options_page": "pages/options.html",
+    "content_scripts": [
+        {
+            "matches": [
+                "https://metalbear.com/mirrord/extension*",
+                "https://www.metalbear.com/mirrord/extension*"
+            ],
+            "js": ["src/content/metalbearConfig.ts"],
+            "run_at": "document_idle"
+        }
+    ],
+    "web_accessible_resources": [
+        {
+            "resources": ["pages/applied.html"],
+            "matches": [
+                "https://metalbear.com/*",
+                "https://www.metalbear.com/*"
+            ]
+        }
+    ]
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -7,7 +7,12 @@ import {
     OperatorSessionSummary,
     ALL_RESOURCE_TYPES,
 } from './types';
-import { STRINGS } from './constants';
+import {
+    STRINGS,
+    METALBEAR_EXTENSION_URL,
+    CONFIG_HASH_PARAM,
+    CONFIG_STORAGE_PARAM,
+} from './constants';
 
 dayjs.extend(relativeTime);
 
@@ -171,8 +176,13 @@ export function buildShareUrl(
     options?: { storage?: 'override' }
 ): string {
     const encoded = encodeConfig(config);
-    const storageParam = options?.storage ? `&storage=${options.storage}` : '';
-    return `chrome-extension://${chrome.runtime.id}/pages/config.html?payload=${encoded}${storageParam}`;
+    const storageParam = options?.storage
+        ? `&${CONFIG_STORAGE_PARAM}=${options.storage}`
+        : '';
+    // Land on metalbear.com so the link works for recipients who don't have the extension yet;
+    // the content script there forwards the payload to the result page. Carried in the hash
+    // (not the query) so the base64 payload survives verbatim and never hits the server.
+    return `${METALBEAR_EXTENSION_URL}#${CONFIG_HASH_PARAM}=${encoded}${storageParam}`;
 }
 
 export type InjectionHint = {

--- a/src/util.ts
+++ b/src/util.ts
@@ -11,7 +11,6 @@ import {
     STRINGS,
     METALBEAR_EXTENSION_URL,
     CONFIG_HASH_PARAM,
-    CONFIG_STORAGE_PARAM,
 } from './constants';
 
 dayjs.extend(relativeTime);
@@ -171,18 +170,12 @@ export function encodeConfig(config: Config): string {
     return btoa(JSON.stringify(config));
 }
 
-export function buildShareUrl(
-    config: Config,
-    options?: { storage?: 'override' }
-): string {
+export function buildShareUrl(config: Config): string {
     const encoded = encodeConfig(config);
-    const storageParam = options?.storage
-        ? `&${CONFIG_STORAGE_PARAM}=${options.storage}`
-        : '';
     // Land on metalbear.com so the link works for recipients who don't have the extension yet;
     // the content script there forwards the payload to the result page. Carried in the hash
     // (not the query) so the base64 payload survives verbatim and never hits the server.
-    return `${METALBEAR_EXTENSION_URL}#${CONFIG_HASH_PARAM}=${encoded}${storageParam}`;
+    return `${METALBEAR_EXTENSION_URL}#${CONFIG_HASH_PARAM}=${encoded}`;
 }
 
 export type InjectionHint = {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
                 configure: resolve(__dirname, 'pages/configure.html'),
                 popup: resolve(__dirname, 'pages/popup.html'),
                 options: resolve(__dirname, 'pages/options.html'),
+                applied: resolve(__dirname, 'pages/applied.html'),
             },
             output: {
                 assetFileNames: '[name].[ext]',


### PR DESCRIPTION
## Summary

Makes `https://metalbear.com/mirrord/extension#config=<payload>` actually do something when the extension is installed. A content script on that path reads the `#config=` hash and redirects the tab to a privileged, web-accessible **result page** (`pages/applied.html`). That page decodes the payload, prompts when the header filter is a regex, installs the DNR rule itself, and shows a success/error card (echoing the offending input on failure). A bare visit (no `#config=`) gets a small in-page note.

Pure decode/parse helpers move to `configCore.ts` (free of module-level side effects) so the content script can import them without dragging in `config.ts`'s page bootstrap; `config.ts` re-exports them so existing importers/tests are unchanged.

This is the **Chrome-only** port of the corresponding work from the `firefox` branch — no monorepo refactor, no `webextension-polyfill`, targets the flat `src/` + static `src/manifest.json`.

## Changes
- `src/content/metalbearConfig.ts` — content script: parse `#config=`, redirect to the result page
- `src/applied.tsx` + `pages/applied.html` — result page (decode, regex prompt, install rule, success/error card)
- `src/applyConfig.ts` — installs the DNR rule + persists the default
- `src/configCore.ts` — side-effect-free `isRegex` / `parseHeader` / `decodeConfig` / `promptForValidHeader`; `config.ts` re-exports
- `src/manifest.json` — content script match + `applied.html` in `web_accessible_resources`
- `vite.config.ts` — `applied.html` build input
- Tests: `applied.test.tsx`, `metalbearConfig.test.ts`

## Stack
First PR in a stack. **Merge this before the rest:**
1. **#PENDING (this)** — metalbear.com config links → result page
2. result page styling
3. mirrord ui token-rejected card
4. mirrord ui detected-but-no-token prompt

## Test plan
- `pnpm test` (172 pass), `pnpm lint`, `pnpm build` all green
- Manual: load `dist/` unpacked, visit `metalbear.com/mirrord/extension#config=<payload>` → lands on the result card and the header is injected
