### PR TITLE
style: match metalbear.com look on the config result page

### DIFF
--- a/pages/applied.html
+++ b/pages/applied.html
@@ -1,27 +1,118 @@
 <!doctype html>
-<html class="dark">
+<html>
     <head>
         <meta charset="utf-8" />
         <title>mirrord — Config Applied</title>
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
         <link
-            href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap"
+            href="https://fonts.googleapis.com/css2?family=Unbounded:wght@400;500;600;700&family=Poppins:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap"
             rel="stylesheet"
         />
         <script type="module" src="../src/applied.tsx"></script>
         <style>
+            :root {
+                --mb-purple: #756df3;
+                --mb-yellow: #ffcb7d;
+                --mb-purple-mid: #e4e3fd;
+                --mb-ink: #232141;
+                --mb-cream: #fffdf9;
+                --mb-grey-50: #fafafd;
+                --mb-grey-500: #888899;
+                --mb-grey-700: #333344;
+                --code-bg: #232141;
+                --code-text: #e2e2f0;
+            }
             html,
             body {
                 margin: 0;
                 padding: 0;
             }
             body {
+                min-height: 100vh;
+                box-sizing: border-box;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                padding: 24px;
+                background: var(--mb-grey-50);
+                color: var(--mb-grey-700);
                 font-family: 'Poppins', system-ui, sans-serif;
+                font-size: 15px;
+                line-height: 1.65;
+            }
+            .mb-card {
+                box-sizing: border-box;
+                width: 100%;
+                max-width: 520px;
+                background: var(--mb-cream);
+                border: 2px solid var(--mb-ink);
+                border-radius: 16px;
+                box-shadow: 4px 5px 0 var(--mb-ink);
+                padding: 28px 32px;
+            }
+            .mb-eyebrow {
+                display: inline-block;
+                font-family: 'Unbounded', system-ui, sans-serif;
+                font-weight: 700;
+                font-size: 11px;
+                letter-spacing: 0.08em;
+                text-transform: uppercase;
+                color: var(--mb-ink);
+                border: 1.5px solid var(--mb-ink);
+                border-radius: 100px;
+                padding: 4px 12px;
+                margin-bottom: 16px;
+            }
+            .mb-eyebrow--success {
+                background: var(--mb-yellow);
+            }
+            .mb-eyebrow--error {
+                background: var(--mb-purple-mid);
+            }
+            .mb-title {
+                font-family: 'Unbounded', system-ui, sans-serif;
+                font-weight: 700;
+                font-size: 24px;
+                line-height: 1.2;
+                letter-spacing: -0.02em;
+                color: #000;
+                margin: 0 0 8px;
+            }
+            .mb-text {
+                margin: 0;
+            }
+            .mb-code {
+                font-family: 'IBM Plex Mono', ui-monospace, monospace;
+                font-size: 13px;
+                background: var(--code-bg);
+                color: var(--code-text);
+                padding: 2px 6px;
+                border-radius: 6px;
+            }
+            .mb-label {
+                font-size: 13px;
+                color: var(--mb-grey-500);
+                margin: 14px 0 6px;
+            }
+            .mb-terminal {
+                margin: 0;
+                font-family: 'IBM Plex Mono', ui-monospace, monospace;
+                font-size: 12px;
+                line-height: 1.5;
+                background: var(--code-bg);
+                color: var(--code-text);
+                border: 2px solid var(--mb-ink);
+                border-radius: 8px;
+                padding: 12px 14px;
+                white-space: pre-wrap;
+                word-break: break-all;
+                max-height: 180px;
+                overflow: auto;
             }
         </style>
     </head>
-    <body class="bg-background text-foreground">
+    <body>
         <div id="root"></div>
     </body>
 </html>

--- a/src/__tests__/applied.test.tsx
+++ b/src/__tests__/applied.test.tsx
@@ -1,16 +1,8 @@
 /** @jest-environment jsdom */
-import React from 'react';
-
-// initTheme touches chrome.storage at module load; stub it so importing applied is safe.
-jest.mock('../theme', () => ({ initTheme: jest.fn() }));
 jest.mock('../analytics', () => ({
     capture: jest.fn(),
     emitUserBlocked: jest.fn(),
     emitUserSucceeded: jest.fn(),
-}));
-jest.mock('@metalbear/ui', () => ({
-    Card: ({ children }: React.PropsWithChildren) => children,
-    CardContent: ({ children }: React.PropsWithChildren) => children,
 }));
 // joinMatchingSession's internals are covered by config.test; here we control its result to
 // exercise run()'s join-vs-static-override orchestration.

--- a/src/applied.tsx
+++ b/src/applied.tsx
@@ -1,14 +1,11 @@
 // Result page the metalbear.com config link lands on. The content script navigates here (a
 // web-accessible extension page) with `?payload=<base64>`; this page decodes it, installs the
 // header rule (it runs as a privileged extension page, so it can call declarativeNetRequest),
-// and shows the outcome — so the user ends up on a real extension page, not the website.
+// and shows the outcome. Styling mirrors metalbear.com (Unbounded/Poppins/IBM Plex Mono,
+// ink-navy stamp card) — see the inline styles in pages/applied.html.
 import { StrictMode, useEffect, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import { ErrorBoundary } from './components/ErrorBoundary';
-import '@metalbear/ui/styles.css';
-import './tokens.css';
-import { initTheme } from './theme';
-import { Card, CardContent } from '@metalbear/ui';
 import {
     decodeConfig,
     isRegex,
@@ -18,8 +15,6 @@ import {
 import { applyHeaderConfig } from './applyConfig';
 import { joinMatchingSession } from './joinSession';
 import { capture, emitUserBlocked, emitUserSucceeded } from './analytics';
-
-initTheme();
 
 export type AppliedState =
     | { kind: 'loading' }
@@ -107,91 +102,62 @@ function AppliedPage() {
     }, []);
 
     return (
-        <div style={{ maxWidth: 520, margin: '24px auto', padding: '0 16px' }}>
-            <Card>
-                <CardContent
-                    style={{
-                        padding: 24,
-                        display: 'flex',
-                        flexDirection: 'column',
-                        gap: 8,
-                    }}
-                >
-                    {state.kind === 'loading' && (
-                        <p className="text-sm text-muted-foreground">
-                            Applying mirrord config…
-                        </p>
-                    )}
-                    {state.kind === 'error' && (
+        <div className="mb-card">
+            {state.kind === 'loading' && (
+                <p className="mb-text">Applying mirrord config…</p>
+            )}
+
+            {state.kind === 'done' && state.joinedKey && (
+                <>
+                    <span className="mb-eyebrow mb-eyebrow--success">
+                        Joined
+                    </span>
+                    <h1 className="mb-title">Joined live session</h1>
+                    <p className="mb-text">
+                        Routing your traffic to session{' '}
+                        <code className="mb-code">{state.joinedKey}</code> by
+                        injecting{' '}
+                        <code className="mb-code">
+                            {state.header}: {state.value}
+                        </code>
+                        .
+                    </p>
+                </>
+            )}
+
+            {state.kind === 'done' && !state.joinedKey && (
+                <>
+                    <span className="mb-eyebrow mb-eyebrow--success">
+                        Configured
+                    </span>
+                    <h1 className="mb-title">mirrord header configured</h1>
+                    <p className="mb-text">
+                        Injecting{' '}
+                        <code className="mb-code">
+                            {state.header}: {state.value}
+                        </code>{' '}
+                        {state.scope
+                            ? `on requests matching ${state.scope}.`
+                            : 'on all requests.'}
+                    </p>
+                </>
+            )}
+
+            {state.kind === 'error' && (
+                <>
+                    <span className="mb-eyebrow mb-eyebrow--error">
+                        Couldn’t apply
+                    </span>
+                    <h1 className="mb-title">Couldn’t apply mirrord config</h1>
+                    <p className="mb-text">{state.error}</p>
+                    {state.input && (
                         <>
-                            <h2 className="text-lg font-semibold">
-                                Couldn’t apply mirrord config
-                            </h2>
-                            <p className="text-sm text-muted-foreground">
-                                {state.error}
-                            </p>
-                            {state.input && (
-                                <>
-                                    <p className="text-meta text-muted-foreground">
-                                        Invalid input:
-                                    </p>
-                                    <pre
-                                        style={{
-                                            margin: 0,
-                                            padding: 12,
-                                            borderRadius: 6,
-                                            background: 'rgba(0, 0, 0, 0.06)',
-                                            fontFamily:
-                                                'ui-monospace, monospace',
-                                            fontSize: 12,
-                                            whiteSpace: 'pre-wrap',
-                                            wordBreak: 'break-all',
-                                            maxHeight: 160,
-                                            overflow: 'auto',
-                                        }}
-                                    >
-                                        {state.input}
-                                    </pre>
-                                </>
-                            )}
+                            <p className="mb-label">Invalid input</p>
+                            <pre className="mb-terminal">{state.input}</pre>
                         </>
                     )}
-                    {state.kind === 'done' && state.joinedKey && (
-                        <>
-                            <h2 className="text-lg font-semibold">
-                                Joined live session
-                            </h2>
-                            <p className="text-sm text-muted-foreground">
-                                Routing your traffic to session{' '}
-                                <code className="font-mono bg-muted px-1 py-0.5 rounded">
-                                    {state.joinedKey}
-                                </code>{' '}
-                                by injecting{' '}
-                                <code className="font-mono bg-muted px-1 py-0.5 rounded">
-                                    {state.header}: {state.value}
-                                </code>
-                                .
-                            </p>
-                        </>
-                    )}
-                    {state.kind === 'done' && !state.joinedKey && (
-                        <>
-                            <h2 className="text-lg font-semibold">
-                                mirrord header configured
-                            </h2>
-                            <p className="text-sm text-muted-foreground">
-                                Injecting{' '}
-                                <code className="font-mono bg-muted px-1 py-0.5 rounded">
-                                    {state.header}: {state.value}
-                                </code>{' '}
-                                {state.scope
-                                    ? `on requests matching ${state.scope}.`
-                                    : 'on all requests.'}
-                            </p>
-                        </>
-                    )}
-                </CardContent>
-            </Card>
+                </>
+            )}
         </div>
     );
 }


### PR DESCRIPTION
## Summary

Pure visual change: restyle the config **result page** (from #57) to the metalbear.com design system instead of the dashboard theme.

- Unbounded / Poppins / IBM Plex Mono fonts
- Light `#FAFAFD` ground
- Cream "stamp" card: 2px ink-navy border + `4px 5px 0` offset shadow
- Eyebrow chip (yellow on success, lavender on error)
- Dark IBM Plex Mono terminal block for the header value and the invalid-input echo

The page is now self-contained — it drops the `@metalbear/ui` Card dependency plus the `theme`/`tokens.css`/`styles.css` imports. No behavior change.

## Stack
Depends on **#57** (`ux/metalbear-config-result-page`). **Merge #57 first.**

3. mirrord ui token-rejected card — _next_
4. mirrord ui detected-but-no-token prompt

## Test plan
`pnpm test` / `pnpm lint` / `pnpm build` green. Manual: trigger a success and a malformed-payload link, confirm the card matches the site look.
