### PR TITLE
feat: mirrord ui token-rejected card

### DIFF
--- a/src/__tests__/SessionsView.test.tsx
+++ b/src/__tests__/SessionsView.test.tsx
@@ -107,6 +107,8 @@ describe('SessionsView', () => {
 
     const baseProps = {
         sessionsLoaded: true,
+        authFailed: false,
+        backend: null as string | null,
         namespaces: ['', 'ns-a', 'ns-b'],
         namespace: '',
         setNamespace: jest.fn(),
@@ -181,6 +183,34 @@ describe('SessionsView', () => {
         );
         expect(screen.getByText(/not configured/i)).toBeInTheDocument();
         expect(screen.getByText('mirrord ui')).toBeInTheDocument();
+    });
+
+    test('renders the auth-error prompt (not run-mirrord-ui) when authFailed', () => {
+        render(
+            <SessionsView
+                {...baseProps}
+                sessions={[]}
+                sessionsLoaded={false}
+                authFailed={true}
+                backend="http://127.0.0.1:8080"
+            />
+        );
+        expect(screen.getByText(/token rejected/i)).toBeInTheDocument();
+        expect(screen.getByText('127.0.0.1:8080')).toBeInTheDocument();
+        expect(screen.queryByText(/not configured/i)).not.toBeInTheDocument();
+    });
+
+    test('auth-error prompt falls back to the default mirrord ui port when backend is unknown', () => {
+        render(
+            <SessionsView
+                {...baseProps}
+                sessions={[]}
+                sessionsLoaded={false}
+                authFailed={true}
+                backend={null}
+            />
+        );
+        expect(screen.getByText('127.0.0.1:59281')).toBeInTheDocument();
     });
 
     test('renders empty-state text when sessions are loaded but list is empty', () => {

--- a/src/__tests__/useMirrordUi.test.ts
+++ b/src/__tests__/useMirrordUi.test.ts
@@ -150,6 +150,32 @@ test('fetches sessions on mount when backend is configured', async () => {
     expect(Object.keys(result.current.groupedFiltered)).toContain('k1');
 });
 
+test('flags authFailed when the poller rejects the token (401)', async () => {
+    global.fetch = jest.fn((url: RequestInfo | URL) => {
+        const u = String(url);
+        if (u.includes('/health')) {
+            return Promise.resolve({
+                ok: true,
+                status: 200,
+                statusText: 'OK',
+                text: () => Promise.resolve('ok'),
+                json: () => Promise.resolve({}),
+            } as unknown as Response);
+        }
+        return Promise.resolve({
+            ok: false,
+            status: 401,
+            statusText: 'Unauthorized',
+            text: () => Promise.resolve('bad token'),
+            json: () => Promise.resolve({}),
+        } as unknown as Response);
+    }) as unknown as typeof fetch;
+
+    const { result } = renderHook(() => useMirrordUi());
+    await waitFor(() => expect(result.current.authFailed).toBe(true));
+    expect(result.current.sessions).toBeNull();
+});
+
 test('namespace filter narrows sessions', async () => {
     const { result } = renderHook(() => useMirrordUi());
     await waitFor(() =>

--- a/src/__tests__/useMirrordUi.test.ts
+++ b/src/__tests__/useMirrordUi.test.ts
@@ -67,11 +67,17 @@ const sampleResponse: OperatorSessionsResponse = {
     watch_status: { status: 'watching' },
 };
 
+let storage: Record<string, unknown>;
+let storageListeners: ((
+    changes: Record<string, chrome.storage.StorageChange>
+) => void)[];
+
 beforeEach(() => {
-    const storage: Record<string, unknown> = {
+    storage = {
         [STORAGE_KEYS.MIRRORD_UI_BACKEND]: 'http://127.0.0.1:8082',
         [STORAGE_KEYS.MIRRORD_UI_TOKEN]: 'tok',
     };
+    storageListeners = [];
     (global as unknown as { chrome: unknown }).chrome = {
         ...((global as unknown as { chrome?: unknown }).chrome ?? {}),
         storage: {
@@ -93,8 +99,30 @@ beforeEach(() => {
                 }),
             },
             onChanged: {
-                addListener: jest.fn(),
-                removeListener: jest.fn(),
+                addListener: jest.fn(
+                    (
+                        l: (
+                            changes: Record<
+                                string,
+                                chrome.storage.StorageChange
+                            >
+                        ) => void
+                    ) => storageListeners.push(l)
+                ),
+                removeListener: jest.fn(
+                    (
+                        l: (
+                            changes: Record<
+                                string,
+                                chrome.storage.StorageChange
+                            >
+                        ) => void
+                    ) => {
+                        storageListeners = storageListeners.filter(
+                            (x) => x !== l
+                        );
+                    }
+                ),
             },
         },
         declarativeNetRequest: {
@@ -174,6 +202,105 @@ test('flags authFailed when the poller rejects the token (401)', async () => {
     const { result } = renderHook(() => useMirrordUi());
     await waitFor(() => expect(result.current.authFailed).toBe(true));
     expect(result.current.sessions).toBeNull();
+});
+
+test('clears authFailed once a freshly stored token is accepted', async () => {
+    global.fetch = jest.fn((url: RequestInfo | URL) => {
+        const u = String(url);
+        if (u.includes('/health')) {
+            return Promise.resolve({
+                ok: true,
+                status: 200,
+                statusText: 'OK',
+                text: () => Promise.resolve('ok'),
+                json: () => Promise.resolve({}),
+            } as unknown as Response);
+        }
+        if (u.includes('token=fresh')) {
+            return Promise.resolve({
+                ok: true,
+                status: 200,
+                statusText: 'OK',
+                text: () => Promise.resolve(JSON.stringify(sampleResponse)),
+                json: () => Promise.resolve(sampleResponse),
+            } as unknown as Response);
+        }
+        return Promise.resolve({
+            ok: false,
+            status: 401,
+            statusText: 'Unauthorized',
+            text: () => Promise.resolve('bad token'),
+            json: () => Promise.resolve({}),
+        } as unknown as Response);
+    }) as unknown as typeof fetch;
+
+    const { result } = renderHook(() => useMirrordUi());
+    await waitFor(() => expect(result.current.authFailed).toBe(true));
+
+    await act(async () => {
+        storage[STORAGE_KEYS.MIRRORD_UI_TOKEN] = 'fresh';
+        storageListeners.forEach((l) =>
+            l({
+                [STORAGE_KEYS.MIRRORD_UI_TOKEN]: {
+                    oldValue: 'tok',
+                    newValue: 'fresh',
+                },
+            })
+        );
+    });
+
+    await waitFor(() => expect(result.current.authFailed).toBe(false));
+    await waitFor(() =>
+        expect(result.current.sessions?.sessions.length).toBe(3)
+    );
+});
+
+test('clears authFailed when a later poll fails for a non-auth reason', async () => {
+    global.fetch = jest.fn((url: RequestInfo | URL) => {
+        const u = String(url);
+        if (u.includes('/health')) {
+            return Promise.resolve({
+                ok: true,
+                status: 200,
+                statusText: 'OK',
+                text: () => Promise.resolve('ok'),
+                json: () => Promise.resolve({}),
+            } as unknown as Response);
+        }
+        if (u.includes('token=other')) {
+            return Promise.resolve({
+                ok: false,
+                status: 503,
+                statusText: 'Service Unavailable',
+                text: () => Promise.resolve('down'),
+                json: () => Promise.resolve({}),
+            } as unknown as Response);
+        }
+        return Promise.resolve({
+            ok: false,
+            status: 401,
+            statusText: 'Unauthorized',
+            text: () => Promise.resolve('bad token'),
+            json: () => Promise.resolve({}),
+        } as unknown as Response);
+    }) as unknown as typeof fetch;
+
+    const { result } = renderHook(() => useMirrordUi());
+    await waitFor(() => expect(result.current.authFailed).toBe(true));
+
+    await act(async () => {
+        storage[STORAGE_KEYS.MIRRORD_UI_TOKEN] = 'other';
+        storageListeners.forEach((l) =>
+            l({
+                [STORAGE_KEYS.MIRRORD_UI_TOKEN]: {
+                    oldValue: 'tok',
+                    newValue: 'other',
+                },
+            })
+        );
+    });
+
+    await waitFor(() => expect(result.current.authFailed).toBe(false));
 });
 
 test('namespace filter narrows sessions', async () => {

--- a/src/components/MirrordUiAuthError.tsx
+++ b/src/components/MirrordUiAuthError.tsx
@@ -1,0 +1,133 @@
+import { useState } from 'react';
+import { AlertTriangle } from 'lucide-react';
+import { Card, CardContent, Input, Button } from '@metalbear/ui';
+import { STRINGS, MIRRORD_UI_DEFAULT_BACKEND } from '../constants';
+import { COLORS } from '../colors';
+import { STORAGE_KEYS } from '../types';
+import { storageSet } from '../util';
+
+// Shown when the mirrord ui poller is reachable but rejects our token (HTTP 401/403) — a
+// stale token, or another process squatting on the port. Offers the two fixes: paste a fresh
+// token (from `mirrord ui`) or re-open the mirrord ui page so it re-sets backend + token.
+export function MirrordUiAuthError({ backend }: { backend: string | null }) {
+    const [tokenInput, setTokenInput] = useState('');
+    // Use the stored backend's actual port when we have it, otherwise fall back to the
+    // default port `mirrord ui` listens on.
+    const uiPage = backend ?? MIRRORD_UI_DEFAULT_BACKEND;
+    const host = uiPage.replace(/^https?:\/\//, '');
+
+    const setToken = async () => {
+        const value = tokenInput.trim();
+        if (!value) return;
+        await storageSet({ [STORAGE_KEYS.MIRRORD_UI_TOKEN]: value });
+        setTokenInput('');
+    };
+
+    return (
+        <Card
+            className="overflow-hidden"
+            style={{
+                borderColor: COLORS.destructive.border,
+                background: COLORS.destructive.bg,
+            }}
+        >
+            <CardContent
+                style={{
+                    padding: 16,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: 10,
+                }}
+            >
+                <div className="flex items-center gap-2">
+                    <AlertTriangle
+                        style={{
+                            height: 14,
+                            width: 14,
+                            color: COLORS.destructive.solid,
+                        }}
+                    />
+                    <span
+                        className="font-semibold text-foreground"
+                        style={{
+                            fontSize: 10.5,
+                            letterSpacing: 'normal',
+                            textTransform: 'none',
+                        }}
+                    >
+                        {STRINGS.MSG_AUTH_FAILED_TITLE}
+                    </span>
+                </div>
+
+                <p
+                    className="text-muted-foreground"
+                    style={{ fontSize: 11, lineHeight: 1.45, margin: 0 }}
+                >
+                    {STRINGS.MSG_AUTH_FAILED_HINT}
+                </p>
+
+                <div
+                    className="rounded-md border border-primary/30 bg-primary/10"
+                    style={{
+                        padding: '10px 12px',
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 8,
+                    }}
+                >
+                    <span
+                        className="font-mono text-muted-foreground"
+                        style={{ fontSize: 12, userSelect: 'none' }}
+                    >
+                        $
+                    </span>
+                    <code
+                        className="font-mono"
+                        style={{
+                            color: COLORS.brand.yellow,
+                            fontSize: 13,
+                            fontWeight: 500,
+                        }}
+                    >
+                        {STRINGS.MSG_MIRRORD_UI_COMMAND}
+                    </code>
+                </div>
+
+                <div className="flex items-center" style={{ gap: 8 }}>
+                    <Input
+                        value={tokenInput}
+                        onChange={(e) => setTokenInput(e.target.value)}
+                        placeholder={STRINGS.PLACEHOLDER_MIRRORD_UI_TOKEN}
+                        aria-label={STRINGS.LABEL_MIRRORD_UI_TOKEN}
+                        spellCheck={false}
+                        autoComplete="off"
+                        className="font-mono"
+                        style={{ flex: 1, height: 32, fontSize: 11 }}
+                    />
+                    <Button
+                        onClick={setToken}
+                        disabled={!tokenInput.trim()}
+                        style={{ height: 32, fontSize: 11 }}
+                    >
+                        {STRINGS.BTN_SET_TOKEN}
+                    </Button>
+                </div>
+
+                <p
+                    className="text-muted-foreground"
+                    style={{ fontSize: 11, lineHeight: 1.45, margin: 0 }}
+                >
+                    {STRINGS.MSG_REOPEN_UI_PAGE}{' '}
+                    <a
+                        href={uiPage}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="font-mono underline"
+                    >
+                        {host}
+                    </a>
+                </p>
+            </CardContent>
+        </Card>
+    );
+}

--- a/src/components/MirrordUiAuthError.tsx
+++ b/src/components/MirrordUiAuthError.tsx
@@ -6,15 +6,18 @@ import { COLORS } from '../colors';
 import { STORAGE_KEYS } from '../types';
 import { storageSet } from '../util';
 
-// Shown when the mirrord ui poller is reachable but rejects our token (HTTP 401/403) — a
-// stale token, or another process squatting on the port. Offers the two fixes: paste a fresh
-// token (from `mirrord ui`) or re-open the mirrord ui page so it re-sets backend + token.
+// Shown when the mirrord ui poller is reachable but rejects our token (HTTP 401/403): a stale
+// token after a mirrord ui restart, or another process on its port. The extension can't fix the
+// token itself (it only holds the rejected one), so it points the user at the two real recoveries:
+// re-run `mirrord ui` (which re-syncs the extension) or paste the current token from ~/.mirrord/token.
 export function MirrordUiAuthError({ backend }: { backend: string | null }) {
     const [tokenInput, setTokenInput] = useState('');
-    // Use the stored backend's actual port when we have it, otherwise fall back to the
-    // default port `mirrord ui` listens on.
-    const uiPage = backend ?? MIRRORD_UI_DEFAULT_BACKEND;
-    const host = uiPage.replace(/^https?:\/\//, '');
+    // The backend whose token was rejected, for display only; falls back to the default port
+    // `mirrord ui` listens on when we have no stored backend.
+    const host = (backend ?? MIRRORD_UI_DEFAULT_BACKEND).replace(
+        /^https?:\/\//,
+        ''
+    );
 
     const setToken = async () => {
         const value = tokenInput.trim();
@@ -117,15 +120,8 @@ export function MirrordUiAuthError({ backend }: { backend: string | null }) {
                     className="text-muted-foreground"
                     style={{ fontSize: 11, lineHeight: 1.45, margin: 0 }}
                 >
-                    {STRINGS.MSG_REOPEN_UI_PAGE}{' '}
-                    <a
-                        href={uiPage}
-                        target="_blank"
-                        rel="noreferrer"
-                        className="font-mono underline"
-                    >
-                        {host}
-                    </a>
+                    {STRINGS.MSG_AUTH_FAILED_BACKEND}{' '}
+                    <code className="font-mono">{host}</code>
                 </p>
             </CardContent>
         </Card>

--- a/src/components/SessionsView.tsx
+++ b/src/components/SessionsView.tsx
@@ -7,6 +7,7 @@ import { ConnectedBanner } from './ConnectedBanner';
 import { NamespaceFilter } from './NamespaceFilter';
 import { StatusDot } from './StatusDot';
 import { NotConfiguredPrompt } from './NotConfiguredPrompt';
+import { MirrordUiAuthError } from './MirrordUiAuthError';
 import { OperatorUnavailableNote } from './OperatorUnavailableNote';
 import type { JoinState } from '../hooks/useMirrordUi';
 import type { OperatorSessionSummary, OperatorWatchStatus } from '../types';
@@ -15,6 +16,8 @@ import { STRINGS } from '../constants';
 type Props = {
     sessions: OperatorSessionSummary[];
     sessionsLoaded: boolean;
+    authFailed: boolean;
+    backend: string | null;
     namespaces: string[];
     namespace: string;
     setNamespace: (ns: string) => void;
@@ -50,6 +53,8 @@ function matchesQuery(s: OperatorSessionSummary, q: string): boolean {
 export function SessionsView({
     sessions,
     sessionsLoaded,
+    authFailed,
+    backend,
     namespaces,
     namespace,
     setNamespace,
@@ -75,6 +80,10 @@ export function SessionsView({
                 matchesQuery(s, normalizedQuery)
         );
     }, [sessions, namespace, normalizedQuery]);
+
+    if (authFailed) {
+        return <MirrordUiAuthError backend={backend} />;
+    }
 
     if (!sessionsLoaded) {
         return <NotConfiguredPrompt />;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -31,6 +31,13 @@ export const STRINGS = {
     MSG_NOT_CONFIGURED: 'Not configured',
     MSG_NOT_CONFIGURED_HINT: 'Run this in your terminal to connect.',
     MSG_MIRRORD_UI_COMMAND: 'mirrord ui',
+    MSG_AUTH_FAILED_TITLE: 'mirrord ui token rejected',
+    MSG_AUTH_FAILED_HINT:
+        'The token seems wrong, or another process is listening on the mirrord ui port. Get a fresh token by running mirrord ui and paste it below, or re-open the mirrord ui page to set it automatically.',
+    LABEL_MIRRORD_UI_TOKEN: 'mirrord ui token',
+    PLACEHOLDER_MIRRORD_UI_TOKEN: 'Paste token from mirrord ui',
+    BTN_SET_TOKEN: 'Set token',
+    MSG_REOPEN_UI_PAGE: 'Re-open mirrord ui page:',
     MSG_NO_ACTIVE_SESSIONS: 'No active sessions yet.',
     MSG_LOCAL_SESSIONS_ONLY: 'Showing local sessions only.',
     MSG_INSTALL_OPERATOR: 'Install the operator',
@@ -142,6 +149,11 @@ export const METALBEAR_EXTENSION_URL =
 // Links are always applied transiently (joined live session, or a reset-able override) and
 // never overwrite the user's saved defaults, so no separate storage-slot param is needed.
 export const CONFIG_HASH_PARAM = 'config';
+
+// Default port `mirrord ui` listens on (its `--port` default).
+// Source: metalbear-co/mirrord — mirrord/cli/src/config.rs `UI_DEFAULT_PORT`.
+export const MIRRORD_UI_DEFAULT_PORT = 59281;
+export const MIRRORD_UI_DEFAULT_BACKEND = `http://127.0.0.1:${MIRRORD_UI_DEFAULT_PORT}`;
 
 export const CONFIGURE_STATUS = {
     LOADING: 'loading',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -33,11 +33,11 @@ export const STRINGS = {
     MSG_MIRRORD_UI_COMMAND: 'mirrord ui',
     MSG_AUTH_FAILED_TITLE: 'mirrord ui token rejected',
     MSG_AUTH_FAILED_HINT:
-        'The token seems wrong, or another process is listening on the mirrord ui port. Get a fresh token by running mirrord ui and paste it below, or re-open the mirrord ui page to set it automatically.',
+        'mirrord ui restarted with a new token, or another process is using its port. Re-run mirrord ui to reconnect automatically. You can also paste the current token below.',
     LABEL_MIRRORD_UI_TOKEN: 'mirrord ui token',
     PLACEHOLDER_MIRRORD_UI_TOKEN: 'Paste token from mirrord ui',
     BTN_SET_TOKEN: 'Set token',
-    MSG_REOPEN_UI_PAGE: 'Re-open mirrord ui page:',
+    MSG_AUTH_FAILED_BACKEND: 'Rejected by mirrord ui at',
     MSG_NO_ACTIVE_SESSIONS: 'No active sessions yet.',
     MSG_LOCAL_SESSIONS_ONLY: 'Showing local sessions only.',
     MSG_INSTALL_OPERATOR: 'Install the operator',

--- a/src/hooks/useMirrordUi.ts
+++ b/src/hooks/useMirrordUi.ts
@@ -40,17 +40,21 @@ export async function fetchOperatorSessions(
     return (await resp.json()) as OperatorSessionsResponse;
 }
 
+export type PollResult =
+    | { ok: true; data: OperatorSessionsResponse }
+    | { ok: false; status?: number; error: string };
+
 export async function runPoll(
     backend: string,
     token: string
-): Promise<OperatorSessionsResponse | null> {
+): Promise<PollResult> {
     try {
         const resp = await fetchOperatorSessions(backend, token);
         if (!bridgeHealthy) {
             bridgeHealthy = true;
             emitUserSucceeded('bridge_recovered', 'health');
         }
-        return resp;
+        return { ok: true, data: resp };
     } catch (err) {
         const error = err instanceof Error ? err.message : String(err);
         const status = (err as { status?: number })?.status;
@@ -61,8 +65,13 @@ export async function runPoll(
                 ...(status !== undefined && { status }),
             });
         }
-        return null;
+        return { ok: false, status, error };
     }
+}
+
+/** True for HTTP responses that indicate the mirrord ui token is wrong / rejected. */
+export function isAuthFailureStatus(status: number | undefined): boolean {
+    return status === 401 || status === 403;
 }
 
 export function buildWsUrl(backend: string, token: string): string {
@@ -133,6 +142,9 @@ export function useMirrordUi() {
     );
     const [status, setStatus] = useState<OperatorWatchStatus | null>(null);
     const [error, setError] = useState<string | null>(null);
+    // The poller is reachable but rejected our token (401/403) — likely a stale token or
+    // another process on the port. Surfaced separately so the UI can tell the user to re-auth.
+    const [authFailed, setAuthFailed] = useState(false);
     const [namespace, setNamespace] = useState<string>('');
     const [joinState, setJoinState] = useState<JoinState>({
         joinedKey: null,
@@ -213,12 +225,15 @@ export function useMirrordUi() {
         if (!backend || !token || healthy !== true) return;
         let cancelled = false;
         const refresh = () => {
-            runPoll(backend, token).then((resp) => {
+            runPoll(backend, token).then((result) => {
                 if (cancelled) return;
-                if (resp !== null) {
-                    setSessions(resp);
-                    setStatus(resp.watch_status);
+                if (result.ok) {
+                    setSessions(result.data);
+                    setStatus(result.data.watch_status);
                     setError(null);
+                    setAuthFailed(false);
+                } else if (isAuthFailureStatus(result.status)) {
+                    setAuthFailed(true);
                 }
             });
         };
@@ -391,6 +406,7 @@ export function useMirrordUi() {
         sessions,
         status,
         error,
+        authFailed,
         namespaces,
         namespace,
         setNamespace,

--- a/src/hooks/useMirrordUi.ts
+++ b/src/hooks/useMirrordUi.ts
@@ -232,8 +232,8 @@ export function useMirrordUi() {
                     setStatus(result.data.watch_status);
                     setError(null);
                     setAuthFailed(false);
-                } else if (isAuthFailureStatus(result.status)) {
-                    setAuthFailed(true);
+                } else {
+                    setAuthFailed(isAuthFailureStatus(result.status));
                 }
             });
         };

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -194,6 +194,8 @@ function SessionsScreen({
         <SessionsView
             sessions={mirrordUi.sessions?.sessions ?? []}
             sessionsLoaded={mirrordUi.sessions !== null}
+            authFailed={mirrordUi.authFailed}
+            backend={mirrordUi.backend}
             namespaces={mirrordUi.namespaces}
             namespace={mirrordUi.namespace}
             setNamespace={mirrordUi.setNamespace}


### PR DESCRIPTION
## Summary

When the `mirrord ui` poller is reachable but **rejects the extension's token** (HTTP 401/403) — a stale token, or another process squatting on the port — the Sessions tab now shows a dedicated **"mirrord ui token rejected"** card instead of the generic run-mirrord-ui prompt. The card lets the user:
- paste a fresh token (run `mirrord ui` to get one), or
- re-open the mirrord ui page to set it automatically (link uses the stored backend's port, falling back to the default `59281`).

`runPoll` now returns a `PollResult` so the hook can distinguish an auth failure from a transport error (`isAuthFailureStatus`); `MIRRORD_UI_DEFAULT_PORT = 59281` is a new constant.

Chrome-only port from the `firefox` branch — only the token-rejection UI; the Firefox content-script bridge from that same upstream commit is **not** included.

## Changes
- `src/components/MirrordUiAuthError.tsx` — the card (paste token / re-open page)
- `src/hooks/useMirrordUi.ts` — `PollResult`, `isAuthFailureStatus`, `authFailed` state
- `src/components/SessionsView.tsx` + `src/popup.tsx` — render the card when `authFailed`
- `src/constants.ts` — strings + `MIRRORD_UI_DEFAULT_PORT` / `_BACKEND`
- Tests: SessionsView (2) + useMirrordUi (1)

## Stack
Depends on **#58** → **#57**. **Merge #57, then #58, then this.**

4. mirrord ui detected-but-no-token prompt — _next, builds on this_

## Test plan
`pnpm test` (175 pass) / `pnpm lint` / `pnpm build` green.
