### PR TITLE
feat: prompt to configure when mirrord ui is detected but token is missing

### DIFF
--- a/src/__tests__/SessionsView.test.tsx
+++ b/src/__tests__/SessionsView.test.tsx
@@ -108,6 +108,7 @@ describe('SessionsView', () => {
     const baseProps = {
         sessionsLoaded: true,
         authFailed: false,
+        uiDetectedNoToken: false,
         backend: null as string | null,
         namespaces: ['', 'ns-a', 'ns-b'],
         namespace: '',
@@ -183,6 +184,21 @@ describe('SessionsView', () => {
         );
         expect(screen.getByText(/not configured/i)).toBeInTheDocument();
         expect(screen.getByText('mirrord ui')).toBeInTheDocument();
+    });
+
+    test('renders the ui-detected prompt when mirrord ui is up but we have no token', () => {
+        render(
+            <SessionsView
+                {...baseProps}
+                sessions={[]}
+                sessionsLoaded={false}
+                uiDetectedNoToken={true}
+            />
+        );
+        expect(screen.getByText(/mirrord ui is running/i)).toBeInTheDocument();
+        const link = screen.getByRole('link', { name: /open mirrord ui/i });
+        expect(link).toHaveAttribute('href', 'http://127.0.0.1:59281');
+        expect(screen.queryByText(/not configured/i)).not.toBeInTheDocument();
     });
 
     test('renders the auth-error prompt (not run-mirrord-ui) when authFailed', () => {

--- a/src/components/MirrordUiDetectedPrompt.tsx
+++ b/src/components/MirrordUiDetectedPrompt.tsx
@@ -1,0 +1,67 @@
+import { ExternalLink, Radio } from 'lucide-react';
+import { Button, Card, CardContent } from '@metalbear/ui';
+import { MIRRORD_UI_DEFAULT_BACKEND, STRINGS } from '../constants';
+import { COLORS } from '../colors';
+
+/**
+ * Shown when the extension has no token but a `mirrord ui` server is answering on the default
+ * port. Tells the user it's running and links to the page so they can get the extension
+ * configured (or re-run `mirrord ui`) without hunting for the URL.
+ */
+export function MirrordUiDetectedPrompt() {
+    return (
+        <Card
+            className="overflow-hidden"
+            style={{
+                borderColor: COLORS.primary.borderSubtle,
+                background: COLORS.primary.bgSoft,
+            }}
+        >
+            <CardContent
+                style={{
+                    padding: 16,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: 10,
+                }}
+            >
+                <div className="flex items-center gap-2">
+                    <Radio
+                        style={{
+                            height: 14,
+                            width: 14,
+                            color: COLORS.brand.lilac,
+                        }}
+                    />
+                    <span
+                        className="font-semibold text-foreground"
+                        style={{
+                            fontSize: 10.5,
+                            letterSpacing: 'normal',
+                            textTransform: 'none',
+                        }}
+                    >
+                        {STRINGS.MSG_UI_DETECTED_TITLE}
+                    </span>
+                </div>
+                <p
+                    className="text-muted-foreground"
+                    style={{ fontSize: 11, lineHeight: 1.45, margin: 0 }}
+                >
+                    {STRINGS.MSG_UI_DETECTED_HINT}
+                </p>
+                <Button asChild size="sm" className="w-full">
+                    <a
+                        href={MIRRORD_UI_DEFAULT_BACKEND}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="inline-flex items-center justify-center gap-1.5"
+                    >
+                        {STRINGS.BTN_OPEN_MIRRORD_UI}
+                        <ExternalLink style={{ height: 12, width: 12 }} />
+                    </a>
+                </Button>
+            </CardContent>
+        </Card>
+    );
+}

--- a/src/components/SessionsView.tsx
+++ b/src/components/SessionsView.tsx
@@ -7,6 +7,7 @@ import { ConnectedBanner } from './ConnectedBanner';
 import { NamespaceFilter } from './NamespaceFilter';
 import { StatusDot } from './StatusDot';
 import { NotConfiguredPrompt } from './NotConfiguredPrompt';
+import { MirrordUiDetectedPrompt } from './MirrordUiDetectedPrompt';
 import { MirrordUiAuthError } from './MirrordUiAuthError';
 import { OperatorUnavailableNote } from './OperatorUnavailableNote';
 import type { JoinState } from '../hooks/useMirrordUi';
@@ -17,6 +18,7 @@ type Props = {
     sessions: OperatorSessionSummary[];
     sessionsLoaded: boolean;
     authFailed: boolean;
+    uiDetectedNoToken: boolean;
     backend: string | null;
     namespaces: string[];
     namespace: string;
@@ -54,6 +56,7 @@ export function SessionsView({
     sessions,
     sessionsLoaded,
     authFailed,
+    uiDetectedNoToken,
     backend,
     namespaces,
     namespace,
@@ -86,7 +89,11 @@ export function SessionsView({
     }
 
     if (!sessionsLoaded) {
-        return <NotConfiguredPrompt />;
+        return uiDetectedNoToken ? (
+            <MirrordUiDetectedPrompt />
+        ) : (
+            <NotConfiguredPrompt />
+        );
     }
 
     const joinedSession = joinState.joinedSessionName

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -31,6 +31,10 @@ export const STRINGS = {
     MSG_NOT_CONFIGURED: 'Not configured',
     MSG_NOT_CONFIGURED_HINT: 'Run this in your terminal to connect.',
     MSG_MIRRORD_UI_COMMAND: 'mirrord ui',
+    MSG_UI_DETECTED_TITLE: 'mirrord ui is running',
+    MSG_UI_DETECTED_HINT:
+        'mirrord ui is up, but the extension doesn’t have its token yet. Open the mirrord ui page to configure it automatically, or re-run mirrord ui.',
+    BTN_OPEN_MIRRORD_UI: 'Open mirrord ui',
     MSG_AUTH_FAILED_TITLE: 'mirrord ui token rejected',
     MSG_AUTH_FAILED_HINT:
         'mirrord ui restarted with a new token, or another process is using its port. Re-run mirrord ui to reconnect automatically. You can also paste the current token below.',

--- a/src/hooks/useMirrordUi.ts
+++ b/src/hooks/useMirrordUi.ts
@@ -8,7 +8,11 @@ import type {
     OperatorWatchStatus,
     SessionNotification,
 } from '../types';
-import { SESSION_NOTIFICATION_TYPE, STRINGS } from '../constants';
+import {
+    MIRRORD_UI_DEFAULT_BACKEND,
+    SESSION_NOTIFICATION_TYPE,
+    STRINGS,
+} from '../constants';
 import {
     storageGet,
     storageSet,
@@ -136,7 +140,11 @@ export type JoinState = {
 export function useMirrordUi() {
     const [backend, setBackend] = useState<string | null>(null);
     const [token, setToken] = useState<string | null>(null);
+    const [configLoaded, setConfigLoaded] = useState(false);
     const [healthy, setHealthy] = useState<boolean | null>(null);
+    // True when we have no token but a `mirrord ui` server is answering on the default port.
+    // Lets the popup tell the user it's running and point them at the page to get configured.
+    const [uiDetectedNoToken, setUiDetectedNoToken] = useState(false);
     const [sessions, setSessions] = useState<OperatorSessionsResponse | null>(
         null
     );
@@ -198,6 +206,7 @@ export function useMirrordUi() {
                       )
                     : []
             );
+            setConfigLoaded(true);
         };
 
         loadFromStorage();
@@ -220,6 +229,32 @@ export function useMirrordUi() {
             .then(setHealthy)
             .catch(() => setHealthy(false));
     }, [backend]);
+
+    // When the extension has no token, poll the default `mirrord ui` port so we can tell the
+    // user it's already running and just needs configuring (instead of the generic "run mirrord
+    // ui" prompt). Stops as soon as a token arrives.
+    useEffect(() => {
+        if (!configLoaded || token) {
+            setUiDetectedNoToken(false);
+            return;
+        }
+        let cancelled = false;
+        const probe = () => {
+            pingHealth(MIRRORD_UI_DEFAULT_BACKEND)
+                .then((ok) => {
+                    if (!cancelled) setUiDetectedNoToken(ok);
+                })
+                .catch(() => {
+                    if (!cancelled) setUiDetectedNoToken(false);
+                });
+        };
+        probe();
+        const interval = setInterval(probe, OPERATOR_SESSIONS_POLL_MS);
+        return () => {
+            cancelled = true;
+            clearInterval(interval);
+        };
+    }, [configLoaded, token]);
 
     useEffect(() => {
         if (!backend || !token || healthy !== true) return;
@@ -403,6 +438,7 @@ export function useMirrordUi() {
     return {
         backend,
         healthy,
+        uiDetectedNoToken,
         sessions,
         status,
         error,

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -195,6 +195,7 @@ function SessionsScreen({
             sessions={mirrordUi.sessions?.sessions ?? []}
             sessionsLoaded={mirrordUi.sessions !== null}
             authFailed={mirrordUi.authFailed}
+            uiDetectedNoToken={mirrordUi.uiDetectedNoToken}
             backend={mirrordUi.backend}
             namespaces={mirrordUi.namespaces}
             namespace={mirrordUi.namespace}


### PR DESCRIPTION
## Summary

When the extension has **no token** but a `mirrord ui` server is answering on the default port (`59281`), the Sessions tab now shows a dedicated **"mirrord ui is running"** prompt with an **Open mirrord ui** button (links to `http://127.0.0.1:59281`) — instead of the generic "run mirrord ui" message. Builds directly on #59 (reuses the `MIRRORD_UI_DEFAULT_PORT` constant and the `SessionsView` state branching).

The probe runs only once config has loaded and there's no token, and stops as soon as a token arrives (so configured users never see it or pay for the polling).

## Changes
- `src/components/MirrordUiDetectedPrompt.tsx` — the prompt
- `src/hooks/useMirrordUi.ts` — poll default port while tokenless; expose `uiDetectedNoToken`
- `src/components/SessionsView.tsx` + `src/popup.tsx` — show detected prompt vs. the generic one
- `src/constants.ts` — strings
- Tests: SessionsView (1)

## Stack
Top of the stack. Depends on **#59** → **#58** → **#57**. **Merge #57, #58, #59, then this.**

## Test plan
`pnpm test` (176 pass) / `pnpm lint` / `pnpm build` green. Manual: with no token stored and `mirrord ui` running, open the popup → "mirrord ui is running" with the Open button; stop `mirrord ui` → reverts to the generic prompt.
