### PR TITLE
feat(mirrord-browser): drop duplicate card for the active session

### DIFF
--- a/src/__tests__/SessionsView.test.tsx
+++ b/src/__tests__/SessionsView.test.tsx
@@ -138,6 +138,13 @@ describe('SessionsView', () => {
         ).toBeNull();
     });
 
+    test('counts unique keys, not raw sessions', () => {
+        // k3 has two sessions; the count should treat that group as one.
+        const withDup = [...sessions, s('d', 'k3', 'ns-a')];
+        render(<SessionsView {...baseProps} sessions={withDup} />);
+        expect(screen.getByText(/3 live sessions/i)).toBeInTheDocument();
+    });
+
     test('clicking Join on a row calls onJoin with that session key', () => {
         const onJoin = jest.fn();
         render(
@@ -161,6 +168,59 @@ describe('SessionsView', () => {
         );
         expect(screen.getByText(/session live/i)).toBeInTheDocument();
         expect(screen.getAllByText('k1').length).toBeGreaterThan(0);
+    });
+
+    test('drops the joined session card from the list (no duplicate)', () => {
+        render(
+            <SessionsView
+                {...baseProps}
+                sessions={sessions}
+                joinState={{
+                    joinedKey: 'k1',
+                    joinedSessionName: 'a',
+                    sessionEnded: false,
+                }}
+            />
+        );
+        // k1 only appears in the banner, not as a second list card.
+        expect(screen.getAllByText('k1')).toHaveLength(1);
+        // The remaining keys still render, and the count excludes the joined one.
+        expect(screen.getByText('k2')).toBeInTheDocument();
+        expect(screen.getByText('k3')).toBeInTheDocument();
+        expect(screen.getByText(/2 live sessions/i)).toBeInTheDocument();
+    });
+
+    test('banner carries the joined session target, owner, and share button', () => {
+        const onShare = jest.fn();
+        const joined: OperatorSessionSummary = {
+            id: 'j',
+            key: 'k9',
+            namespace: 'ns',
+            owner: { username: 'bob', k8sUsername: 'bob@ex' },
+            target: { kind: 'Deployment', name: 'inventory', container: 'app' },
+            createdAt: '2026-01-01T00:00:00Z',
+        };
+        render(
+            <SessionsView
+                {...baseProps}
+                sessions={[...sessions, joined]}
+                onShare={onShare}
+                joinState={{
+                    joinedKey: 'k9',
+                    joinedSessionName: 'j',
+                    sessionEnded: false,
+                }}
+            />
+        );
+        // Affected service (target name) and user (owner) surface in the banner.
+        expect(screen.getByText('inventory')).toBeInTheDocument();
+        expect(screen.getByText(/bob/)).toBeInTheDocument();
+        fireEvent.click(
+            screen.getByRole('button', {
+                name: /copy override link for k9/i,
+            })
+        );
+        expect(onShare).toHaveBeenCalledWith('k9');
     });
 
     test('shows session-ended banner when joined session was removed', () => {

--- a/src/components/ConnectedBanner.tsx
+++ b/src/components/ConnectedBanner.tsx
@@ -1,5 +1,14 @@
 import { useState, useRef, useEffect } from 'react';
-import { Activity, Check, Copy, Globe, X, Plus } from 'lucide-react';
+import {
+    Activity,
+    Box,
+    Check,
+    Copy,
+    Globe,
+    Share2,
+    X,
+    Plus,
+} from 'lucide-react';
 import { Button, Input } from '@metalbear/ui';
 import type { OperatorSessionSummary } from '../types';
 import { STRINGS } from '../constants';
@@ -7,12 +16,18 @@ import { COLORS } from '../colors';
 import { RING_SECONDS } from '../headerObservation';
 import { useHeaderObservation } from '../hooks/useHeaderObservation';
 import { StatusDot } from './StatusDot';
+import {
+    aggregateSessions,
+    formatRelativeTime,
+    targetDisplayName,
+} from '../util';
 
 type Props = {
     joinedKey: string;
-    session: OperatorSessionSummary | undefined;
+    sessions: OperatorSessionSummary[];
     sessionEnded: boolean;
     onLeave: () => void;
+    onShare: () => void;
     scopePatterns: string[];
     onAddScopePattern: (pattern: string) => void | Promise<void>;
     onRemoveScopePattern: (pattern: string) => void | Promise<void>;
@@ -20,16 +35,32 @@ type Props = {
     joinedValue: string | null;
 };
 
+const MAX_TARGETS = 4;
+
 export function ConnectedBanner({
     joinedKey,
+    sessions,
     sessionEnded,
     onLeave,
+    onShare,
     scopePatterns,
     onAddScopePattern,
     onRemoveScopePattern,
     joinedHeader,
     joinedValue,
 }: Props) {
+    const agg = aggregateSessions(sessions);
+    const shownTargets = agg.targets.slice(0, MAX_TARGETS);
+    const overflowTargets = agg.targets.length - shownTargets.length;
+    const age = formatRelativeTime(agg.earliestCreatedAt);
+    const ownerLabel = agg.isPreview
+        ? 'preview'
+        : agg.owners.length === 1
+          ? agg.owners[0]
+          : agg.owners.length > 1
+            ? `${agg.owners.length} owners`
+            : '';
+    const metaParts = [ownerLabel, age].filter(Boolean);
     const label = sessionEnded
         ? STRINGS.MSG_SESSION_ENDED
         : STRINGS.MSG_SESSION_LIVE;
@@ -129,16 +160,89 @@ export function ConnectedBanner({
                         {joinedKey}
                     </div>
                 </div>
-                <Button
-                    type="button"
-                    size="sm"
-                    variant="outline"
-                    onClick={onLeave}
-                    style={{ height: 28, padding: '0 12px' }}
-                >
-                    {buttonLabel}
-                </Button>
+                <div className="flex items-center" style={{ gap: 6 }}>
+                    {!sessionEnded && (
+                        <Button
+                            type="button"
+                            size="icon"
+                            variant="ghost"
+                            onClick={onShare}
+                            aria-label={`Copy override link for ${joinedKey}`}
+                            title="Copy override link"
+                            style={{ height: 28, width: 28 }}
+                        >
+                            <Share2 style={{ height: 14, width: 14 }} />
+                        </Button>
+                    )}
+                    <Button
+                        type="button"
+                        size="sm"
+                        variant="outline"
+                        onClick={onLeave}
+                        style={{ height: 28, padding: '0 12px' }}
+                    >
+                        {buttonLabel}
+                    </Button>
+                </div>
             </div>
+
+            {(shownTargets.length > 0 || metaParts.length > 0) && (
+                <div
+                    className="flex flex-col"
+                    style={{
+                        gap: 4,
+                        paddingTop: 8,
+                        borderTop: `1px dashed ${COLORS.primary.borderSubtle}`,
+                    }}
+                >
+                    {shownTargets.map((t) => (
+                        <div
+                            key={t}
+                            className="flex items-center gap-2 min-w-0"
+                        >
+                            <Box
+                                className="shrink-0 text-muted-foreground"
+                                style={{ height: 13, width: 13 }}
+                            />
+                            <div
+                                className="min-w-0 font-mono font-bold"
+                                style={{
+                                    fontSize: 12,
+                                    lineHeight: 1.45,
+                                    color: COLORS.brand.lilac,
+                                    overflow: 'hidden',
+                                    textOverflow: 'ellipsis',
+                                    whiteSpace: 'nowrap',
+                                }}
+                            >
+                                {targetDisplayName(t)}
+                            </div>
+                        </div>
+                    ))}
+                    {overflowTargets > 0 && (
+                        <div
+                            className="text-muted-foreground"
+                            style={{ paddingLeft: 21, fontSize: 11 }}
+                        >
+                            + {overflowTargets} more target
+                            {overflowTargets === 1 ? '' : 's'}
+                        </div>
+                    )}
+                    {metaParts.length > 0 && (
+                        <div
+                            className="text-muted-foreground"
+                            style={{
+                                fontSize: 11,
+                                overflow: 'hidden',
+                                textOverflow: 'ellipsis',
+                                whiteSpace: 'nowrap',
+                            }}
+                        >
+                            {metaParts.join(' · ')}
+                        </div>
+                    )}
+                </div>
+            )}
 
             {!sessionEnded && (
                 <div

--- a/src/components/SessionKeyGroup.tsx
+++ b/src/components/SessionKeyGroup.tsx
@@ -8,7 +8,12 @@ import {
     Separator,
 } from '@metalbear/ui';
 import type { OperatorSessionSummary } from '../types';
-import { formatRelativeTime } from '../util';
+import {
+    aggregateSessions,
+    formatRelativeTime,
+    targetDisplayName,
+    type SessionGroupAggregate,
+} from '../util';
 import { STRINGS } from '../constants';
 import { COLORS } from '../colors';
 import { StatusDot } from './StatusDot';
@@ -28,48 +33,6 @@ const TRUNCATE_STYLE: React.CSSProperties = {
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
 };
-
-type GroupAggregate = {
-    targets: string[];
-    owners: string[];
-    namespaces: string[];
-    earliestCreatedAt: string | null;
-    isPreview: boolean;
-};
-
-const PREVIEW_OWNER_USERNAME = 'preview-env';
-
-function aggregate(sessions: OperatorSessionSummary[]): GroupAggregate {
-    const targets = new Set<string>();
-    const owners = new Set<string>();
-    const namespaces = new Set<string>();
-    let earliest: string | null = null;
-    let isPreview = false;
-
-    for (const s of sessions) {
-        const targetLabel = s.target
-            ? `${s.target.kind}/${s.target.name}`
-            : 'targetless';
-        targets.add(targetLabel);
-        if (s.owner?.username === PREVIEW_OWNER_USERNAME) {
-            isPreview = true;
-        } else if (s.owner?.username) {
-            owners.add(s.owner.username);
-        }
-        namespaces.add(s.namespace);
-        if (s.createdAt && (!earliest || s.createdAt < earliest)) {
-            earliest = s.createdAt;
-        }
-    }
-
-    return {
-        targets: Array.from(targets),
-        owners: Array.from(owners),
-        namespaces: Array.from(namespaces),
-        earliestCreatedAt: earliest,
-        isPreview,
-    };
-}
 
 function GroupHeader({
     groupKey,
@@ -136,8 +99,7 @@ function GroupHeader({
 }
 
 function TargetRow({ target }: { target: string }) {
-    const slashIdx = target.indexOf('/');
-    const name = slashIdx >= 0 ? target.slice(slashIdx + 1) : target;
+    const name = targetDisplayName(target);
     return (
         <div className="flex items-center gap-2 min-w-0">
             <Box
@@ -163,7 +125,7 @@ function GroupMeta({
     agg,
     sessionCount,
 }: {
-    agg: GroupAggregate;
+    agg: SessionGroupAggregate;
     sessionCount: number;
 }) {
     const age = formatRelativeTime(agg.earliestCreatedAt);
@@ -253,7 +215,7 @@ export function SessionKeyGroup({
     onJoin,
     onShare,
 }: Props) {
-    const agg = aggregate(sessions);
+    const agg = aggregateSessions(sessions);
     const shownTargets = agg.targets.slice(0, MAX_TARGETS);
     const overflow = agg.targets.length - shownTargets.length;
 

--- a/src/components/SessionsView.tsx
+++ b/src/components/SessionsView.tsx
@@ -104,19 +104,24 @@ export function SessionsView({
     const groups = groupBy(filtered, (s) => s.key);
 
     const joinedKey = joinState.joinedKey;
-    const otherKeys = Object.keys(groups)
+    // The joined session is represented by the ConnectedBanner above, so drop its
+    // card from the list to avoid showing the same session twice.
+    const orderedKeys = Object.keys(groups)
         .filter((k) => k !== joinedKey)
         .sort((a, b) => a.localeCompare(b));
-    const orderedKeys =
-        joinedKey && groups[joinedKey] ? [joinedKey, ...otherKeys] : otherKeys;
+    // Source the joined group from the full session list (not `filtered`) so the
+    // banner's meta survives search/namespace filtering.
+    const joinedSessions = joinedKey
+        ? sessions.filter((s) => s.key === joinedKey)
+        : [];
 
     const hasNamespaces = namespaces.filter((ns) => ns !== '').length > 0;
     const watching = status?.status === 'watching';
     const operatorUnavailable = status?.status === 'unavailable';
     const hasGroups = orderedKeys.length > 0;
-    const totalSessionsBeforeQuery = namespace
-        ? sessions.filter((s) => s.namespace === namespace).length
-        : sessions.length;
+    const totalSessionsBeforeQuery = sessions.filter(
+        (s) => (!namespace || s.namespace === namespace) && s.key !== joinedKey
+    ).length;
     const showSearch = totalSessionsBeforeQuery > 0;
 
     const VISIBLE_CAP = 5;
@@ -131,9 +136,10 @@ export function SessionsView({
             {joinState.joinedKey && (
                 <ConnectedBanner
                     joinedKey={joinState.joinedKey}
-                    session={joinedSession}
+                    sessions={joinedSessions}
                     sessionEnded={effectiveSessionEnded}
                     onLeave={onClear}
+                    onShare={() => onShare(joinState.joinedKey!)}
                     scopePatterns={scopePatterns}
                     onAddScopePattern={onAddScopePattern}
                     onRemoveScopePattern={onRemoveScopePattern}
@@ -201,7 +207,7 @@ export function SessionsView({
                         }}
                     >
                         <span>
-                            {filtered.length} {STRINGS.MSG_LIVE_SESSIONS}
+                            {orderedKeys.length} {STRINGS.MSG_LIVE_SESSIONS}
                         </span>
                         {status && (
                             <span

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -45,6 +45,12 @@ export function Popup() {
     const headerRules = useHeaderRules();
     const mirrordUi = useMirrordUi();
 
+    // Sessions sharing a key are presented as one group, so count distinct keys
+    // (not raw sessions) to match the list below.
+    const sessionKeyCount = new Set(
+        (mirrordUi.sessions?.sessions ?? []).map((s) => s.key)
+    ).size;
+
     const [tab, setTab] = useState<TabId>(TAB.MANUAL);
     const [tabRestored, setTabRestored] = useState(false);
     const [themePref, setThemeState] = useState<ThemePref>('system');
@@ -150,8 +156,7 @@ export function Popup() {
                         <TabsTrigger value={TAB.SESSIONS}>
                             <span className="inline-flex items-center gap-1.5">
                                 {STRINGS.TAB_SESSIONS}
-                                {(mirrordUi.sessions?.sessions.length ?? 0) >
-                                    0 && (
+                                {sessionKeyCount > 0 && (
                                     <span
                                         className="font-mono"
                                         style={{
@@ -164,7 +169,7 @@ export function Popup() {
                                             lineHeight: 1.4,
                                         }}
                                     >
-                                        {mirrordUi.sessions?.sessions.length}
+                                        {sessionKeyCount}
                                     </span>
                                 )}
                             </span>

--- a/src/util.ts
+++ b/src/util.ts
@@ -166,6 +166,56 @@ export function formatRelativeTime(iso: string | null | undefined): string {
     return parsed.fromNow();
 }
 
+export const PREVIEW_OWNER_USERNAME = 'preview-env';
+
+export type SessionGroupAggregate = {
+    targets: string[];
+    owners: string[];
+    namespaces: string[];
+    earliestCreatedAt: string | null;
+    isPreview: boolean;
+};
+
+export function aggregateSessions(
+    sessions: OperatorSessionSummary[]
+): SessionGroupAggregate {
+    const targets = new Set<string>();
+    const owners = new Set<string>();
+    const namespaces = new Set<string>();
+    let earliest: string | null = null;
+    let isPreview = false;
+
+    for (const s of sessions) {
+        const targetLabel = s.target
+            ? `${s.target.kind}/${s.target.name}`
+            : 'targetless';
+        targets.add(targetLabel);
+        if (s.owner?.username === PREVIEW_OWNER_USERNAME) {
+            isPreview = true;
+        } else if (s.owner?.username) {
+            owners.add(s.owner.username);
+        }
+        namespaces.add(s.namespace);
+        if (s.createdAt && (!earliest || s.createdAt < earliest)) {
+            earliest = s.createdAt;
+        }
+    }
+
+    return {
+        targets: Array.from(targets),
+        owners: Array.from(owners),
+        namespaces: Array.from(namespaces),
+        earliestCreatedAt: earliest,
+        isPreview,
+    };
+}
+
+// Targets are stored as `kind/name`; the UI shows just the name.
+export function targetDisplayName(target: string): string {
+    const slashIdx = target.indexOf('/');
+    return slashIdx >= 0 ? target.slice(slashIdx + 1) : target;
+}
+
 export function encodeConfig(config: Config): string {
     return btoa(JSON.stringify(config));
 }


### PR DESCRIPTION
## Summary

While dogfooding, an active session showed up twice — once as the connected banner at the top, and again as a `JOINED` card in the live-sessions list below. This drops the duplicate and consolidates the info into the banner.

- **Drop the joined session's card from the list** (`SessionsView.tsx`) — the joined session is already represented by the `ConnectedBanner`, so it no longer appears a second time in the list. The live-sessions count excludes it too.
- **Move share + session details into the banner** (`ConnectedBanner.tsx`) — added a share (copy override link) button next to **Leave**, plus a meta block with the affected services (targets), user (owner), and start time, so nothing is lost when the duplicate card disappears.
- **Count by unique key, not raw sessions** (`popup.tsx`, `SessionsView.tsx`) — a key with multiple sessions (e.g. a preview group) now counts once in both the tab badge and the "N Live sessions" header.
- **Shared aggregation helper** (`util.ts`) — extracted `aggregateSessions` / `targetDisplayName` out of `SessionKeyGroup` so the list card and the banner derive targets/owner/start time from one place.

## Testing

- `pnpm test` — 182 passing, incl. new coverage for the dropped duplicate, the banner carrying target/owner/share, and unique-key counting.
- `pnpm run check` — lint + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)