### PR TITLE
ci(mirrord-browser): match operator/mirrord CI shape + add release automation

### DIFF
--- a/.github/workflows/auto-release-pr.yaml
+++ b/.github/workflows/auto-release-pr.yaml
@@ -4,6 +4,8 @@ on:
     workflow_call:
     workflow_dispatch:
 
+permissions: {}
+
 jobs:
     auto-release-pr:
         runs-on: ubuntu-latest

--- a/.github/workflows/auto-release-pr.yaml
+++ b/.github/workflows/auto-release-pr.yaml
@@ -11,7 +11,7 @@ jobs:
             contents: read
         steps:
             - name: Checkout main
-              uses: actions/checkout@v4
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
               with:
                   ref: main
                   persist-credentials: false

--- a/.github/workflows/auto-release-pr.yaml
+++ b/.github/workflows/auto-release-pr.yaml
@@ -1,0 +1,117 @@
+name: Auto Release PR
+
+on:
+    workflow_call:
+    workflow_dispatch:
+
+jobs:
+    auto-release-pr:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+        steps:
+            - name: Checkout main
+              uses: actions/checkout@v4
+              with:
+                  ref: main
+                  persist-credentials: false
+                  fetch-depth: 0
+
+            - name: Install uv
+              uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+
+            - name: Install Python
+              run: uv python install
+
+            - name: Create virtual environment
+              run: uv venv
+
+            - name: Install towncrier
+              run: uv pip install towncrier==25.8.0
+
+            - name: Determine version bump type
+              id: bump-type
+              run: |
+                  shopt -s nullglob
+                  bump=patch
+                  for f in changelog.d/*.md; do
+                    [[ "$(basename "$f")" == changelog_template* ]] && continue
+                    # Fragment names follow the pattern: +description.type.md
+                    type=$(basename "$f" | rev | cut -d. -f2 | rev)
+                    if [[ "$type" != "internal" && "$type" != "fixed" ]]; then
+                      bump=minor
+                      break
+                    fi
+                  done
+                  echo "bump=$bump" >> "$GITHUB_OUTPUT"
+
+            - name: Compute next version
+              id: version
+              run: |
+                  current=$(node -p "require('./package.json').version")
+                  IFS='.' read -r major minor patch <<< "$current"
+                  if [[ "${{ steps.bump-type.outputs.bump }}" == "minor" ]]; then
+                    new_version="${major}.$((minor + 1)).0"
+                  else
+                    new_version="${major}.${minor}.$((patch + 1))"
+                  fi
+                  echo "new_version=$new_version" >> "$GITHUB_OUTPUT"
+
+            - name: Update package.json version
+              run: npm pkg set version="${{ steps.version.outputs.new_version }}"
+
+            - name: Update manifest.json version
+              run: |
+                  version="${{ steps.version.outputs.new_version }}"
+                  tmp=$(mktemp)
+                  jq --arg v "$version" '.version = $v' src/manifest.json > "$tmp"
+                  mv "$tmp" src/manifest.json
+
+            - name: Build release notes draft
+              run: |
+                  uv run -- towncrier build \
+                    --draft \
+                    --version ${{ steps.version.outputs.new_version }} \
+                    > /tmp/release-notes.md
+
+            - name: Build changelog
+              run: |
+                  uv run -- towncrier build \
+                    --yes \
+                    --version ${{ steps.version.outputs.new_version }}
+
+            - name: Create GitHub App token
+              id: app-token
+              uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+              with:
+                  app-id: ${{ secrets.CUBBY_CLIENT_ID }}
+                  private-key: ${{ secrets.CUBBY_PRIVATE_KEY }}
+                  permission-contents: write
+                  permission-pull-requests: write
+
+            - name: Push release branch and create or update PR
+              env:
+                  GH_TOKEN: ${{ steps.app-token.outputs.token }}
+                  BRANCH: releases/${{ steps.version.outputs.new_version }}
+                  VERSION: ${{ steps.version.outputs.new_version }}
+              run: |
+                  git config user.name "github-actions[bot]"
+                  git config user.email "github-actions[bot]@users.noreply.github.com"
+                  git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}"
+                  git checkout -b "$BRANCH"
+                  git add -A
+                  git commit -m "chore(mirrord-browser): release v$VERSION"
+                  git push origin "$BRANCH" --force
+
+                  existing_pr=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // empty')
+                  if [[ -n "$existing_pr" ]]; then
+                    gh pr edit "$existing_pr" \
+                      --title "chore(mirrord-browser): release v$VERSION" \
+                      --body-file /tmp/release-notes.md
+                  else
+                    gh pr create \
+                      --head "$BRANCH" \
+                      --base main \
+                      --title "chore(mirrord-browser): release v$VERSION" \
+                      --body-file /tmp/release-notes.md
+                  fi

--- a/.github/workflows/check-lint.yaml
+++ b/.github/workflows/check-lint.yaml
@@ -3,13 +3,14 @@ name: Check Lint and Format
 on:
     workflow_call:
 
-permissions:
-    contents: read
+permissions: {}
 
 jobs:
     lint-and-format:
         name: Lint and Format Check
         runs-on: ubuntu-latest
+        permissions:
+            contents: read
         steps:
             - name: Checkout code
               uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/check-lint.yaml
+++ b/.github/workflows/check-lint.yaml
@@ -1,0 +1,29 @@
+name: Check Lint and Format
+
+on:
+    workflow_call:
+
+permissions:
+    contents: read
+
+jobs:
+    lint-and-format:
+        name: Lint and Format Check
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Set up Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: '24'
+
+            - name: Install pnpm
+              run: npm install -g pnpm@10
+
+            - name: Install dependencies
+              run: pnpm install --frozen-lockfile
+
+            - name: Run format and lint checks
+              run: pnpm run check

--- a/.github/workflows/check-lint.yaml
+++ b/.github/workflows/check-lint.yaml
@@ -12,10 +12,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
             - name: Set up Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
                   node-version: '24'
 

--- a/.github/workflows/check-towncrier.yaml
+++ b/.github/workflows/check-towncrier.yaml
@@ -11,7 +11,7 @@ jobs:
         name: Check Changelog Fragment
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
               with:
                   fetch-depth: 0
             - name: Install uv

--- a/.github/workflows/check-towncrier.yaml
+++ b/.github/workflows/check-towncrier.yaml
@@ -3,13 +3,14 @@ name: Check Towncrier
 on:
     workflow_call:
 
-permissions:
-    contents: read
+permissions: {}
 
 jobs:
     towncrier:
         name: Check Changelog Fragment
         runs-on: ubuntu-latest
+        permissions:
+            contents: read
         steps:
             - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
               with:

--- a/.github/workflows/check-towncrier.yaml
+++ b/.github/workflows/check-towncrier.yaml
@@ -1,0 +1,26 @@
+name: Check Towncrier
+
+on:
+    workflow_call:
+
+permissions:
+    contents: read
+
+jobs:
+    towncrier:
+        name: Check Changelog Fragment
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+            - name: Install uv
+              uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+              with:
+                  enable-cache: false
+            - run: uv python install
+            - run: uv venv
+            - name: Install towncrier
+              run: uv pip install towncrier==25.8.0
+            - name: Verify that newsfragment exists
+              run: uv run towncrier check --config towncrier.toml --compare-with origin/main

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,92 +1,56 @@
 name: CI
 
 on:
+    workflow_dispatch:
     push:
         branches: [main]
     pull_request:
         branches: [main]
+        types: [opened, synchronize, reopened, ready_for_review]
+
+# Cancel previous runs on the same PR.
+concurrency:
+    group: ${{ github.head_ref || github.run_id }}
+    cancel-in-progress: true
 
 permissions:
     contents: read
 
 jobs:
-    lint-and-format:
-        name: Lint and Format Check
+    check-lint:
+        uses: ./.github/workflows/check-lint.yaml
+
+    check-towncrier:
+        # Changelog fragments are only meaningful relative to a PR's base branch.
+        if: github.event_name == 'pull_request'
+        uses: ./.github/workflows/check-towncrier.yaml
+
+    test-unit:
+        uses: ./.github/workflows/test-unit.yaml
+
+    test-e2e:
+        uses: ./.github/workflows/test-e2e.yaml
+
+    # ── gate ────────────────────────────────────────────────────────────
+    # Single required status check for branch protection.
+    # It depends on every other job and only passes if none of them failed.
+    ci-success:
+        name: ci
+        # Run even if some required jobs were skipped.
+        if: always()
+        needs: [check-lint, check-towncrier, test-unit, test-e2e]
         runs-on: ubuntu-latest
-
         steps:
-            - name: Checkout code
-              uses: actions/checkout@v3
-
-            - name: Set up Node.js
-              uses: actions/setup-node@v3
-              with:
-                  node-version: '24'
-
-            - name: Install pnpm
-              run: npm install -g pnpm@10
-
-            - name: Install dependencies
-              run: pnpm install --frozen-lockfile
-
-            - name: Run format and lint checks
-              run: pnpm run check
-
-    test:
-        name: Run Tests
-        runs-on: ubuntu-latest
-        needs: lint-and-format
-
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@v3
-
-            - name: Set up Node.js
-              uses: actions/setup-node@v3
-              with:
-                  node-version: '24'
-
-            - name: Install pnpm
-              run: npm install -g pnpm@10
-
-            - name: Install dependencies
-              run: pnpm install --frozen-lockfile
-
-            - name: Run Tests
-              run: pnpm test
-
-    e2e:
-        name: E2E Tests
-        runs-on: ubuntu-latest
-        needs: lint-and-format
-        timeout-minutes: 20
-        container:
-            image: mcr.microsoft.com/playwright:v1.58.1-jammy
-
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@v3
-
-            - name: Set up Node.js
-              uses: actions/setup-node@v3
-              with:
-                  node-version: '24'
-
-            - name: Install pnpm
-              run: npm install -g pnpm@10
-
-            - name: Install dependencies
-              run: pnpm install --frozen-lockfile
-
-            - name: Build extension
-              run: pnpm build
-
-            - name: Run E2E tests
-              run: xvfb-run pnpm test:e2e
-
-            - name: Upload Playwright report
-              uses: actions/upload-artifact@v4
-              if: failure()
-              with:
-                  name: playwright-report
-                  path: playwright-report/
+            - name: Check required jobs passed
+              # Done in the shell because a job-level `if` treats a skipped
+              # dependency as success under branch protection rules.
+              env:
+                  NEEDS_JSON: ${{ toJSON(needs) }}
+              run: |
+                  failing=$(echo "$NEEDS_JSON" | jq -r 'to_entries[] | select(.value.result != "success" and .value.result != "skipped") | "\(.key): \(.value.result)"')
+                  if [ -n "$failing" ]; then
+                    echo "The following required jobs did not succeed:"
+                    echo "$failing"
+                    exit 1
+                  fi
+                  echo "All required jobs passed."

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,22 +13,29 @@ concurrency:
     group: ${{ github.head_ref || github.run_id }}
     cancel-in-progress: true
 
-permissions:
-    contents: read
+permissions: {}
 
 jobs:
     check-lint:
+        permissions:
+            contents: read
         uses: ./.github/workflows/check-lint.yaml
 
     check-towncrier:
         # Changelog fragments are only meaningful relative to a PR's base branch.
         if: github.event_name == 'pull_request'
+        permissions:
+            contents: read
         uses: ./.github/workflows/check-towncrier.yaml
 
     test-unit:
+        permissions:
+            contents: read
         uses: ./.github/workflows/test-unit.yaml
 
     test-e2e:
+        permissions:
+            contents: read
         uses: ./.github/workflows/test-e2e.yaml
 
     # ── gate ────────────────────────────────────────────────────────────
@@ -40,6 +47,7 @@ jobs:
         if: always()
         needs: [check-lint, check-towncrier, test-unit, test-e2e]
         runs-on: ubuntu-latest
+        permissions: {}
         steps:
             - name: Check required jobs passed
               # Done in the shell because a job-level `if` treats a skipped

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
         steps:
             - name: Checkout
               if: github.event_name == 'pull_request'
-              uses: actions/checkout@v4
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
             - name: Validate and output version
               id: validate
@@ -74,10 +74,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
             - name: Set up Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
                   node-version: '24'
 
@@ -97,7 +97,7 @@ jobs:
               run: cd dist && zip -r ../extension.zip .
 
             - name: Upload extension artifact
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
                   name: extension
                   path: extension.zip
@@ -143,12 +143,12 @@ jobs:
             VERSION: ${{ needs.validate_release_request.outputs.version }}
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
               with:
                   fetch-depth: 0
 
             - name: Download extension artifact
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
               with:
                   name: extension
 
@@ -173,7 +173,7 @@ jobs:
         needs: [validate_release_request, create-release]
         if: needs.validate_release_request.outputs.should_release == 'true'
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
               with:
                   fetch-depth: 0 # Required for commit history
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,6 @@
 name: Publish
 
-permissions:
-    contents: read
+permissions: {}
 
 on:
     pull_request:
@@ -12,6 +11,8 @@ on:
 jobs:
     validate_release_request:
         runs-on: ubuntu-latest
+        permissions:
+            contents: read
         outputs:
             should_release: ${{ steps.validate.outputs.should_release }}
             version: ${{ steps.validate.outputs.version }}
@@ -72,6 +73,8 @@ jobs:
         needs: [validate_release_request]
         if: needs.validate_release_request.outputs.should_release == 'true'
         runs-on: ubuntu-latest
+        permissions:
+            contents: read
         steps:
             - name: Checkout code
               uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,16 +1,77 @@
-name: Release
-
-on:
-    push:
-        tags: ['v*']
+name: Publish
 
 permissions:
-    contents: write
+    contents: read
+
+on:
+    pull_request:
+        branches: [main]
+        types: [closed]
+    workflow_dispatch:
 
 jobs:
-    build-and-publish:
+    validate_release_request:
         runs-on: ubuntu-latest
+        outputs:
+            should_release: ${{ steps.validate.outputs.should_release }}
+            version: ${{ steps.validate.outputs.version }}
+        steps:
+            - name: Checkout
+              if: github.event_name == 'pull_request'
+              uses: actions/checkout@v4
 
+            - name: Validate and output version
+              id: validate
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: |
+                  if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+                    echo "should_release=false" >> "$GITHUB_OUTPUT"
+                    echo "version=" >> "$GITHUB_OUTPUT"
+                    exit 0
+                  fi
+
+                  if [[ "${{ github.event.pull_request.merged }}" != "true" ]]; then
+                    echo "PR was not merged, skipping release"
+                    echo "should_release=false" >> "$GITHUB_OUTPUT"
+                    echo "version=" >> "$GITHUB_OUTPUT"
+                    exit 0
+                  fi
+
+                  if [[ "${{ github.head_ref }}" != releases/* ]]; then
+                    echo "Branch '${{ github.head_ref }}' does not start with releases/, skipping"
+                    echo "should_release=false" >> "$GITHUB_OUTPUT"
+                    echo "version=" >> "$GITHUB_OUTPUT"
+                    exit 0
+                  fi
+
+                  version=$(node -p "require('./package.json').version")
+                  manifest_version=$(node -p "require('./src/manifest.json').version")
+
+                  if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                    echo "Version '$version' does not match semver, aborting" >&2
+                    exit 1
+                  fi
+
+                  if [[ "$manifest_version" != "$version" ]]; then
+                    echo "manifest.json version ($manifest_version) does not match package.json version ($version)" >&2
+                    exit 1
+                  fi
+
+                  if gh release view "$version" &>/dev/null; then
+                    echo "Release $version already exists, skipping"
+                    echo "should_release=false" >> "$GITHUB_OUTPUT"
+                    echo "version=" >> "$GITHUB_OUTPUT"
+                    exit 0
+                  fi
+
+                  echo "should_release=true" >> "$GITHUB_OUTPUT"
+                  echo "version=$version" >> "$GITHUB_OUTPUT"
+
+    build-and-publish:
+        needs: [validate_release_request]
+        if: needs.validate_release_request.outputs.should_release == 'true'
+        runs-on: ubuntu-latest
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
@@ -26,26 +87,6 @@ jobs:
             - name: Install dependencies
               run: pnpm install --frozen-lockfile
 
-            - name: Validate version matches tag
-              run: |
-                  TAG_VERSION="${GITHUB_REF_NAME#v}"
-                  PKG_VERSION=$(node -p "require('./package.json').version")
-                  MANIFEST_VERSION=$(node -p "require('./src/manifest.json').version")
-                  echo "Tag version: $TAG_VERSION"
-                  echo "package.json version: $PKG_VERSION"
-                  echo "manifest.json version: $MANIFEST_VERSION"
-                  if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
-                    echo "::error::package.json version ($PKG_VERSION) does not match tag ($TAG_VERSION)"
-                    exit 1
-                  fi
-                  # manifest.json may use shorter format (e.g. "0.3" vs "0.3.0")
-                  # Strip trailing ".0" segments from tag for comparison
-                  TAG_SHORT=$(echo "$TAG_VERSION" | sed 's/\.0$//')
-                  if [ "$MANIFEST_VERSION" != "$TAG_VERSION" ] && [ "$MANIFEST_VERSION" != "$TAG_SHORT" ]; then
-                    echo "::error::manifest.json version ($MANIFEST_VERSION) does not match tag ($TAG_VERSION or $TAG_SHORT)"
-                    exit 1
-                  fi
-
             - name: Run tests
               run: pnpm test
 
@@ -54,6 +95,14 @@ jobs:
 
             - name: Zip extension
               run: cd dist && zip -r ../extension.zip .
+
+            - name: Upload extension artifact
+              uses: actions/upload-artifact@v4
+              with:
+                  name: extension
+                  path: extension.zip
+                  if-no-files-found: error
+                  retention-days: 1
 
             - name: Upload to Chrome Web Store
               run: |
@@ -84,7 +133,52 @@ jobs:
                     -H "x-goog-api-version: 2")
                   echo "$PUBLISH_RESPONSE"
 
+    create-release:
+        needs: [validate_release_request, build-and-publish]
+        if: needs.validate_release_request.outputs.should_release == 'true'
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+        env:
+            VERSION: ${{ needs.validate_release_request.outputs.version }}
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+
+            - name: Download extension artifact
+              uses: actions/download-artifact@v4
+              with:
+                  name: extension
+
+            - name: Extract release notes from CHANGELOG.md
+              run: |
+                  awk "/^## \[${VERSION}\]/{found=1} found && /^## \[/ && !/^## \[${VERSION}\]/{exit} found{print}" \
+                    CHANGELOG.md > /tmp/release-notes.md
+
             - name: Create GitHub Release
               env:
                   GH_TOKEN: ${{ github.token }}
-              run: gh release create "$GITHUB_REF_NAME" extension.zip --generate-notes
+              run: |
+                  gh release create "$VERSION" \
+                    --title "$VERSION" \
+                    --notes-file /tmp/release-notes.md \
+                    extension.zip
+
+    linear_release:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+        needs: [validate_release_request, create-release]
+        if: needs.validate_release_request.outputs.should_release == 'true'
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0 # Required for commit history
+
+            - uses: metalbear-co/linear-release-action@76a250988b9470b152ec13d24d661140084042c1
+              with:
+                  access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+                  version: ${{ needs.validate_release_request.outputs.version }}
+                  name: ${{ needs.validate_release_request.outputs.version }}

--- a/.github/workflows/reviewpal.yml
+++ b/.github/workflows/reviewpal.yml
@@ -7,6 +7,8 @@ on:
     issue_comment:
         types: [created]
 
+permissions: {}
+
 jobs:
     review:
         runs-on: ubuntu-latest

--- a/.github/workflows/scheduled-release.yaml
+++ b/.github/workflows/scheduled-release.yaml
@@ -1,0 +1,46 @@
+name: Scheduled Release
+
+on:
+    schedule:
+        # 10:00 UTC on Sunday, Monday, Tuesday, Wednesday
+        - cron: '0 10 * * 0-3'
+    workflow_dispatch:
+
+jobs:
+    check-conditions:
+        runs-on: ubuntu-latest
+        outputs:
+            should_release: ${{ steps.check.outputs.should_release }}
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Check release conditions
+              id: check
+              run: |
+                  shopt -s nullglob
+                  # Only release when there's at least one user-facing change.
+                  # Internal-only fragments don't warrant a release on their own.
+                  user_facing=0
+                  for f in changelog.d/*.md; do
+                    [[ "$(basename "$f")" == changelog_template* ]] && continue
+                    # Fragment names follow the pattern: +description.type.md
+                    type=$(basename "$f" | rev | cut -d. -f2 | rev)
+                    if [[ "$type" != "internal" ]]; then
+                      user_facing=$((user_facing + 1))
+                    fi
+                  done
+
+                  if [[ "$user_facing" -eq 0 ]]; then
+                    echo "No user-facing changelog fragments found, skipping release"
+                    echo "should_release=false" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "Found $user_facing user-facing changelog fragment(s), proceeding"
+                    echo "should_release=true" >> "$GITHUB_OUTPUT"
+                  fi
+
+    trigger-release:
+        needs: check-conditions
+        if: needs.check-conditions.outputs.should_release == 'true'
+        uses: ./.github/workflows/auto-release-pr.yaml
+        secrets: inherit

--- a/.github/workflows/scheduled-release.yaml
+++ b/.github/workflows/scheduled-release.yaml
@@ -13,7 +13,7 @@ jobs:
             should_release: ${{ steps.check.outputs.should_release }}
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
             - name: Check release conditions
               id: check

--- a/.github/workflows/scheduled-release.yaml
+++ b/.github/workflows/scheduled-release.yaml
@@ -6,9 +6,13 @@ on:
         - cron: '0 10 * * 0-3'
     workflow_dispatch:
 
+permissions: {}
+
 jobs:
     check-conditions:
         runs-on: ubuntu-latest
+        permissions:
+            contents: read
         outputs:
             should_release: ${{ steps.check.outputs.should_release }}
         steps:
@@ -42,5 +46,7 @@ jobs:
     trigger-release:
         needs: check-conditions
         if: needs.check-conditions.outputs.should_release == 'true'
+        permissions:
+            contents: read
         uses: ./.github/workflows/auto-release-pr.yaml
         secrets: inherit

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -15,10 +15,10 @@ jobs:
             image: mcr.microsoft.com/playwright:v1.58.1-jammy
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
             - name: Set up Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
                   node-version: '24'
 
@@ -35,7 +35,7 @@ jobs:
               run: xvfb-run pnpm test:e2e
 
             - name: Upload Playwright report
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               if: failure()
               with:
                   name: playwright-report

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -3,14 +3,15 @@ name: E2E Tests
 on:
     workflow_call:
 
-permissions:
-    contents: read
+permissions: {}
 
 jobs:
     test-e2e:
         name: E2E Tests
         runs-on: ubuntu-latest
         timeout-minutes: 20
+        permissions:
+            contents: read
         container:
             image: mcr.microsoft.com/playwright:v1.58.1-jammy
         steps:

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -1,0 +1,42 @@
+name: E2E Tests
+
+on:
+    workflow_call:
+
+permissions:
+    contents: read
+
+jobs:
+    test-e2e:
+        name: E2E Tests
+        runs-on: ubuntu-latest
+        timeout-minutes: 20
+        container:
+            image: mcr.microsoft.com/playwright:v1.58.1-jammy
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Set up Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: '24'
+
+            - name: Install pnpm
+              run: npm install -g pnpm@10
+
+            - name: Install dependencies
+              run: pnpm install --frozen-lockfile
+
+            - name: Build extension
+              run: pnpm build
+
+            - name: Run E2E tests
+              run: xvfb-run pnpm test:e2e
+
+            - name: Upload Playwright report
+              uses: actions/upload-artifact@v4
+              if: failure()
+              with:
+                  name: playwright-report
+                  path: playwright-report/

--- a/.github/workflows/test-unit.yaml
+++ b/.github/workflows/test-unit.yaml
@@ -1,0 +1,29 @@
+name: Unit Tests
+
+on:
+    workflow_call:
+
+permissions:
+    contents: read
+
+jobs:
+    test-unit:
+        name: Run Tests
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Set up Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: '24'
+
+            - name: Install pnpm
+              run: npm install -g pnpm@10
+
+            - name: Install dependencies
+              run: pnpm install --frozen-lockfile
+
+            - name: Run Tests
+              run: pnpm test

--- a/.github/workflows/test-unit.yaml
+++ b/.github/workflows/test-unit.yaml
@@ -3,13 +3,14 @@ name: Unit Tests
 on:
     workflow_call:
 
-permissions:
-    contents: read
+permissions: {}
 
 jobs:
     test-unit:
         name: Run Tests
         runs-on: ubuntu-latest
+        permissions:
+            contents: read
         steps:
             - name: Checkout code
               uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/test-unit.yaml
+++ b/.github/workflows/test-unit.yaml
@@ -12,10 +12,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
             - name: Set up Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
                   node-version: '24'
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,9 @@
+dist
+node_modules
+pnpm-lock.yaml
+playwright-report
+test-results
+
+# Changelog content is generated/managed by towncrier
+CHANGELOG.md
+changelog.d

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+This project uses [*towncrier*](https://towncrier.readthedocs.io/) and the changes for the upcoming release can be found in <https://github.com/metalbear-co/mirrord-browser/tree/main/changelog.d/>.
+
+<!-- towncrier release notes start -->
+
+## [0.5.0](https://github.com/metalbear-co/mirrord-browser/tree/0.5.0) - 2026-06-18
+
+Initial changelog entry. Releases before this point are tracked in the
+[GitHub releases](https://github.com/metalbear-co/mirrord-browser/releases) page.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ mirrord-browser is a Chrome extension (Manifest V3) that injects HTTP headers in
 - **Language:** TypeScript (strict mode, ES6 target, jsx: react-jsx)
 - **UI:** React 19 with @metalbear/ui (Radix-based components) and Tailwind CSS
 - **Build:** Vite 5.4 with @crxjs/vite-plugin for Chrome extension bundling
-- **Published to:** Chrome Web Store (automated on git tag)
+- **Published to:** Chrome Web Store (automated when a `releases/*` PR is merged)
 
 ## Architecture
 
@@ -123,5 +123,19 @@ The `live-real.spec.ts` spec auto-skips when `MIRRORD_UI_TOKEN` is unset, so CI 
 
 ## CI/CD
 
-- **ci.yaml:** lint/format check, Jest unit tests, Playwright E2E (xvfb-run on Ubuntu)
-- **release.yaml:** On git tag, validates version match (package.json + manifest.json), builds, uploads to Chrome Web Store via API, creates GitHub release
+Layout mirrors the operator/mirrord repos: small reusable check/test workflows orchestrated by `ci.yaml`, with a single `ci` gate job for branch protection.
+
+- **ci.yaml:** orchestrator. Calls `check-lint.yaml`, `check-towncrier.yaml`, `test-unit.yaml`, `test-e2e.yaml` (each a reusable `workflow_call`), then a final `ci` gate job (`ci-success`) that fails if any required job failed. Triggers on `pull_request`, `push` to main, and `workflow_dispatch`; concurrency cancels superseded PR runs.
+- **check-lint.yaml:** `pnpm run check` (Prettier + ESLint).
+- **check-towncrier.yaml:** verifies a changelog fragment was added (PR-only).
+- **test-unit.yaml:** Jest unit tests.
+- **test-e2e.yaml:** Playwright E2E in the playwright container (xvfb-run), uploads report on failure.
+
+### Release automation (towncrier-based, like operator/mirrord)
+
+- **Changelog fragments:** add a `changelog.d/+<description>.<type>.md` file per change (types: `security`, `removed`, `deprecated`, `added`, `changed`, `fixed`, `internal`). `internal`/`fixed`-only releases bump the patch version; anything else bumps the minor version. Config in `towncrier.toml`, accumulated history in `CHANGELOG.md`.
+- **scheduled-release.yaml:** daily cron, Sun–Wed (and manual dispatch). If any user-facing (non-`internal`) fragments exist, calls `auto-release-pr.yaml`.
+- **auto-release-pr.yaml:** computes the next version, bumps `package.json` + `src/manifest.json`, builds the changelog with towncrier, and opens/updates a `releases/<version>` PR. Uses the CUBBY GitHub App token so CI runs on the PR.
+- **release.yaml (Publish):** triggers when a `releases/*` PR is **merged** into main. Validates the version (semver, package.json == manifest.json, not already released), runs tests, builds, zips, uploads/publishes to the Chrome Web Store, creates a GitHub release with notes extracted from `CHANGELOG.md`, then records the release in Linear via `metalbear-co/linear-release-action`.
+
+**Required secrets:** `CWS_CLIENT_ID`, `CWS_CLIENT_SECRET`, `CWS_REFRESH_TOKEN`, `CWS_EXTENSION_ID` (Chrome Web Store); `CUBBY_CLIENT_ID`, `CUBBY_PRIVATE_KEY` (release-PR app token); `LINEAR_ACCESS_KEY` (Linear release).

--- a/changelog.d/+ci-release-automation.internal.md
+++ b/changelog.d/+ci-release-automation.internal.md
@@ -1,0 +1,1 @@
+Reshape CI into reusable check/test workflows with a final `ci` merge gate, and add towncrier-based release automation with Linear release integration.

--- a/changelog.d/changelog_template.jinja
+++ b/changelog.d/changelog_template.jinja
@@ -1,0 +1,15 @@
+{% if sections[""] %}
+{% for category, val in definitions.items() if category in sections[""] and category != "internal" %}
+
+### {{ definitions[category]['name'] }}
+
+{% for text, values in sections[""][category].items() %}
+- {{ text }} {{ values|join(', ') }}
+{% endfor %}
+
+{% endfor %}
+{% else %}
+No significant changes.
+
+
+{% endif %}

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -1,0 +1,46 @@
+[tool.towncrier]
+directory = "changelog.d"
+filename = "CHANGELOG.md"
+start_string = "<!-- towncrier release notes start -->\n"
+underlines = ["", "", ""]
+template = "changelog.d/changelog_template.jinja"
+title_format = "## [{version}](https://github.com/metalbear-co/mirrord-browser/tree/{version}) - {project_date}"
+issue_format = "[#{issue}](https://github.com/metalbear-co/mirrord-browser/issues/{issue})"
+# We link to GitHub, and GitHub issues are made only out of digits.
+issue_pattern = "\\d+"
+wrap = true
+
+[[tool.towncrier.type]]
+directory = "security"
+name = "Security"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "removed"
+name = "Removed"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "deprecated"
+name = "Deprecated"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "added"
+name = "Added"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "changed"
+name = "Changed"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "fixed"
+name = "Fixed"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "internal"
+name = "Internal"
+showcontent = true


### PR DESCRIPTION
Resolves PRO-128 and PRO-124.

## PRO-128 — CI reshaped to match operator/mirrord

`ci.yaml` is now a thin orchestrator that calls small reusable `workflow_call` files and ends in a single `ci` merge-gate job — the same shape as the operator/mirrord repos. Test coverage/steps are unchanged; only the layout changed.

- **check-lint.yaml** — `pnpm run check` (Prettier + ESLint)
- **test-unit.yaml** — Jest
- **test-e2e.yaml** — Playwright in the playwright container with `xvfb-run` (+ report upload on failure)
- **check-towncrier.yaml** — verifies a changelog fragment exists (PR-only)
- **ci.yaml** — calls the above, adds `workflow_dispatch` + concurrency-cancel, ends with a `ci` gate job (`ci-success`, `if: always()`, jq check treating skipped as OK) for branch protection. No merge queue.

## PRO-124 — Release automation + Linear release

Mirrors operator's towncrier-driven flow, adapted to the node/extension project:

- **towncrier.toml + changelog.d/ + CHANGELOG.md** — changelog fragments (`+desc.<type>.md`); `internal`/`fixed`-only → patch bump, anything else → minor bump.
- **scheduled-release.yaml** — daily cron Sun–Wed; opens a release PR only when user-facing (non-`internal`) fragments exist.
- **auto-release-pr.yaml** — computes next version, bumps `package.json` + `src/manifest.json`, builds the changelog, opens/updates a `releases/<version>` PR (CUBBY app token so CI runs on it).
- **release.yaml (Publish)** — triggers on a merged `releases/*` PR: validates version, runs tests, builds, zips, uploads + publishes to Chrome Web Store, creates a GitHub release with notes from `CHANGELOG.md`, then records the release in Linear via `metalbear-co/linear-release-action`.

## Required secrets

`CWS_CLIENT_ID`, `CWS_CLIENT_SECRET`, `CWS_REFRESH_TOKEN`, `CWS_EXTENSION_ID` (Chrome Web Store); `CUBBY_CLIENT_ID`, `CUBBY_PRIVATE_KEY` (release-PR app token); `LINEAR_ACCESS_KEY` (Linear release).

## Notes

- Point branch protection's required status check at the new `ci` job.
- Pre-commit ran the full suite — 182 tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)