### PR TITLE
fix: hold joined banner through session reconnects with an amber grace state

### DIFF
--- a/changelog.d/+joined-session-reconnect-grace.fixed.md
+++ b/changelog.d/+joined-session-reconnect-grace.fixed.md
@@ -1,0 +1,1 @@
+The joined-session banner no longer flips to "Session ended" when the local `mirrord` session reconnects (stop → start). Liveness now tracks the session key rather than a specific session id, and a session that drops out shows an amber "Waiting for session" state for a grace period before it can be dismissed.

--- a/src/__tests__/SessionsView.test.tsx
+++ b/src/__tests__/SessionsView.test.tsx
@@ -1,5 +1,5 @@
 /** @jest-environment jsdom */
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import React from 'react';
 import type { OperatorSessionSummary, OperatorWatchStatus } from '../types';
@@ -116,7 +116,6 @@ describe('SessionsView', () => {
         joinState: {
             joinedKey: null,
             joinedSessionName: null,
-            sessionEnded: false,
         },
         status: { status: 'watching' } as OperatorWatchStatus,
         onJoin: jest.fn(),
@@ -162,7 +161,6 @@ describe('SessionsView', () => {
                 joinState={{
                     joinedKey: 'k1',
                     joinedSessionName: 'a',
-                    sessionEnded: false,
                 }}
             />
         );
@@ -178,7 +176,6 @@ describe('SessionsView', () => {
                 joinState={{
                     joinedKey: 'k1',
                     joinedSessionName: 'a',
-                    sessionEnded: false,
                 }}
             />
         );
@@ -208,7 +205,6 @@ describe('SessionsView', () => {
                 joinState={{
                     joinedKey: 'k9',
                     joinedSessionName: 'j',
-                    sessionEnded: false,
                 }}
             />
         );
@@ -223,19 +219,46 @@ describe('SessionsView', () => {
         expect(onShare).toHaveBeenCalledWith('k9');
     });
 
-    test('shows session-ended banner when joined session was removed', () => {
+    test('stays live while a session still holds the joined key (survives reconnect)', () => {
+        // The joined session id ("old") is gone, but another session reclaimed the
+        // same key ("k1") — a stop → start reconnect. The banner must read live.
         render(
             <SessionsView
                 {...baseProps}
                 sessions={sessions}
-                joinState={{
-                    joinedKey: 'k1',
-                    joinedSessionName: 'a',
-                    sessionEnded: true,
-                }}
+                joinState={{ joinedKey: 'k1', joinedSessionName: 'old' }}
             />
         );
-        expect(screen.getByText(/session ended/i)).toBeInTheDocument();
+        expect(screen.getByText(/session live/i)).toBeInTheDocument();
+        expect(screen.queryByText(/session ended/i)).not.toBeInTheDocument();
+    });
+
+    test('holds an amber waiting state, then ends after the grace period', () => {
+        jest.useFakeTimers();
+        try {
+            render(
+                <SessionsView
+                    {...baseProps}
+                    sessions={sessions}
+                    joinState={{ joinedKey: 'gone', joinedSessionName: 'x' }}
+                />
+            );
+            // No session holds key "gone": don't dismiss yet — wait it out.
+            expect(
+                screen.getByText(/waiting for session/i)
+            ).toBeInTheDocument();
+            expect(
+                screen.queryByText(/session ended/i)
+            ).not.toBeInTheDocument();
+
+            act(() => {
+                jest.advanceTimersByTime(60_000);
+            });
+
+            expect(screen.getByText(/session ended/i)).toBeInTheDocument();
+        } finally {
+            jest.useRealTimers();
+        }
     });
 
     test('renders the not-configured prompt when sessions have not loaded', () => {

--- a/src/colors.ts
+++ b/src/colors.ts
@@ -19,6 +19,15 @@ export const COLORS = {
         bg: 'hsl(var(--destructive) / 0.1)',
         glow: 'hsl(var(--destructive) / 0.22)',
     },
+    // Amber, used for the "session might be coming back" grace state before we
+    // commit to declaring it ended. Falls back to a fixed amber when the theme
+    // doesn't define --brand-amber, mirroring how success leans on --brand-green.
+    warning: {
+        solid: 'hsl(var(--brand-amber, 38 92% 50%))',
+        border: 'hsl(var(--brand-amber, 38 92% 50%) / 0.4)',
+        bg: 'hsl(var(--brand-amber, 38 92% 50%) / 0.1)',
+        glow: 'hsl(var(--brand-amber, 38 92% 50%) / 0.22)',
+    },
     success: {
         dot: 'hsl(var(--brand-green, 142 71% 45%))',
         glow: 'hsl(var(--brand-green, 142 71% 45%) / 0.22)',

--- a/src/components/ConnectedBanner.tsx
+++ b/src/components/ConnectedBanner.tsx
@@ -15,6 +15,7 @@ import { STRINGS } from '../constants';
 import { COLORS } from '../colors';
 import { RING_SECONDS } from '../headerObservation';
 import { useHeaderObservation } from '../hooks/useHeaderObservation';
+import type { JoinLiveness } from '../hooks/useJoinLiveness';
 import { StatusDot } from './StatusDot';
 import {
     aggregateSessions,
@@ -25,7 +26,7 @@ import {
 type Props = {
     joinedKey: string;
     sessions: OperatorSessionSummary[];
-    sessionEnded: boolean;
+    liveness: JoinLiveness;
     onLeave: () => void;
     onShare: () => void;
     scopePatterns: string[];
@@ -40,7 +41,7 @@ const MAX_TARGETS = 4;
 export function ConnectedBanner({
     joinedKey,
     sessions,
-    sessionEnded,
+    liveness,
     onLeave,
     onShare,
     scopePatterns,
@@ -61,17 +62,30 @@ export function ConnectedBanner({
             ? `${agg.owners.length} owners`
             : '';
     const metaParts = [ownerLabel, age].filter(Boolean);
-    const label = sessionEnded
+    const ended = liveness === 'ended';
+    const pending = liveness === 'pending';
+    const label = ended
         ? STRINGS.MSG_SESSION_ENDED
-        : STRINGS.MSG_SESSION_LIVE;
-    const buttonLabel = sessionEnded ? STRINGS.BTN_DISMISS : STRINGS.BTN_LEAVE;
-    const border = sessionEnded
+        : pending
+          ? STRINGS.MSG_SESSION_RECONNECTING
+          : STRINGS.MSG_SESSION_LIVE;
+    const buttonLabel = ended ? STRINGS.BTN_DISMISS : STRINGS.BTN_LEAVE;
+    const dotTone = ended ? 'destructive' : pending ? 'warning' : 'active';
+    const border = ended
         ? COLORS.destructive.border
-        : COLORS.primary.borderSoft;
-    const bg = sessionEnded ? COLORS.destructive.bg : COLORS.primary.bg;
-    const titleColor = sessionEnded
+        : pending
+          ? COLORS.warning.border
+          : COLORS.primary.borderSoft;
+    const bg = ended
+        ? COLORS.destructive.bg
+        : pending
+          ? COLORS.warning.bg
+          : COLORS.primary.bg;
+    const titleColor = ended
         ? COLORS.destructive.solid
-        : COLORS.brand.lilac;
+        : pending
+          ? COLORS.warning.solid
+          : COLORS.brand.lilac;
 
     const [draft, setDraft] = useState('');
     const [composing, setComposing] = useState(false);
@@ -93,11 +107,11 @@ export function ConnectedBanner({
     };
 
     useEffect(() => {
-        if (sessionEnded) {
+        if (ended) {
             setDraft('');
             setComposing(false);
         }
-    }, [sessionEnded]);
+    }, [ended]);
 
     useEffect(() => {
         if (composing) inputRef.current?.focus();
@@ -130,10 +144,7 @@ export function ConnectedBanner({
             }}
         >
             <div className="flex items-center" style={{ gap: 10 }}>
-                <StatusDot
-                    tone={sessionEnded ? 'destructive' : 'active'}
-                    glow
-                />
+                <StatusDot tone={dotTone} glow />
                 <div className="min-w-0" style={{ flex: 1 }}>
                     <div
                         className="font-semibold"
@@ -161,7 +172,7 @@ export function ConnectedBanner({
                     </div>
                 </div>
                 <div className="flex items-center" style={{ gap: 6 }}>
-                    {!sessionEnded && (
+                    {!ended && (
                         <Button
                             type="button"
                             size="icon"
@@ -244,7 +255,7 @@ export function ConnectedBanner({
                 </div>
             )}
 
-            {!sessionEnded && (
+            {!ended && (
                 <div
                     className="flex flex-col"
                     style={{

--- a/src/components/SessionsView.tsx
+++ b/src/components/SessionsView.tsx
@@ -11,8 +11,9 @@ import { MirrordUiDetectedPrompt } from './MirrordUiDetectedPrompt';
 import { MirrordUiAuthError } from './MirrordUiAuthError';
 import { OperatorUnavailableNote } from './OperatorUnavailableNote';
 import type { JoinState } from '../hooks/useMirrordUi';
+import { useJoinLiveness } from '../hooks/useJoinLiveness';
 import type { OperatorSessionSummary, OperatorWatchStatus } from '../types';
-import { STRINGS } from '../constants';
+import { JOIN_GRACE_MS, STRINGS } from '../constants';
 
 type Props = {
     sessions: OperatorSessionSummary[];
@@ -84,6 +85,17 @@ export function SessionsView({
         );
     }, [sessions, namespace, normalizedQuery]);
 
+    // Liveness is keyed on the session *key*, not the joined session's id: a local
+    // stop → start swaps the id but keeps the key, so this rides through reconnects.
+    const joinedKey = joinState.joinedKey;
+    const joinedLive =
+        joinedKey !== null && sessions.some((s) => s.key === joinedKey);
+    const liveness = useJoinLiveness(
+        joinedKey !== null,
+        joinedLive,
+        JOIN_GRACE_MS
+    );
+
     if (authFailed) {
         return <MirrordUiAuthError backend={backend} />;
     }
@@ -96,14 +108,8 @@ export function SessionsView({
         );
     }
 
-    const joinedSession = joinState.joinedSessionName
-        ? sessions.find((s) => s.id === joinState.joinedSessionName)
-        : undefined;
-    const joinedVanished = joinState.joinedKey !== null && !joinedSession;
-    const effectiveSessionEnded = joinState.sessionEnded || joinedVanished;
     const groups = groupBy(filtered, (s) => s.key);
 
-    const joinedKey = joinState.joinedKey;
     // The joined session is represented by the ConnectedBanner above, so drop its
     // card from the list to avoid showing the same session twice.
     const orderedKeys = Object.keys(groups)
@@ -137,7 +143,7 @@ export function SessionsView({
                 <ConnectedBanner
                     joinedKey={joinState.joinedKey}
                     sessions={joinedSessions}
-                    sessionEnded={effectiveSessionEnded}
+                    liveness={liveness}
                     onLeave={onClear}
                     onShare={() => onShare(joinState.joinedKey!)}
                     scopePatterns={scopePatterns}

--- a/src/components/StatusDot.tsx
+++ b/src/components/StatusDot.tsx
@@ -1,6 +1,6 @@
 import { COLORS } from '../colors';
 
-type Tone = 'active' | 'muted' | 'destructive' | 'inactive';
+type Tone = 'active' | 'muted' | 'destructive' | 'inactive' | 'warning';
 
 type Props = {
     size?: number;
@@ -13,6 +13,7 @@ const TONE_COLOR: Record<Tone, string> = {
     muted: COLORS.muted.dot,
     destructive: COLORS.destructive.solid,
     inactive: COLORS.muted.dotInactive,
+    warning: COLORS.warning.solid,
 };
 
 const TONE_GLOW: Record<Tone, string> = {
@@ -20,6 +21,7 @@ const TONE_GLOW: Record<Tone, string> = {
     muted: COLORS.muted.glow,
     destructive: COLORS.destructive.glow,
     inactive: COLORS.muted.glowInactive,
+    warning: COLORS.warning.glow,
 };
 
 export function StatusDot({ size = 8, tone, glow = false }: Props) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -52,6 +52,7 @@ export const STRINGS = {
     MSG_SHOW_LESS: 'Show less',
     MSG_USE_SEARCH_HINT: 'Use search to narrow down',
     MSG_SESSION_LIVE: 'Session live',
+    MSG_SESSION_RECONNECTING: 'Waiting for session',
     MSG_SESSION_ENDED: 'Session ended',
     MSG_ROUTING_TRAFFIC: 'Routing your traffic',
     MSG_AVAILABLE: 'Available',
@@ -158,6 +159,12 @@ export const CONFIG_HASH_PARAM = 'config';
 // Source: metalbear-co/mirrord — mirrord/cli/src/config.rs `UI_DEFAULT_PORT`.
 export const MIRRORD_UI_DEFAULT_PORT = 59281;
 export const MIRRORD_UI_DEFAULT_BACKEND = `http://127.0.0.1:${MIRRORD_UI_DEFAULT_PORT}`;
+
+// How long the joined banner stays in the amber "waiting" state after the session
+// disappears from the operator's list before it gives up and shows "ended". A local
+// `mirrord` stop → start reclaims the key well within this window, so the banner
+// rides through the reconnect instead of prompting the user to dismiss a live session.
+export const JOIN_GRACE_MS = 60_000;
 
 export const CONFIGURE_STATUS = {
     LOADING: 'loading',

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export { useHeaderRules } from './useHeaderRules';
+export { useJoinLiveness, type JoinLiveness } from './useJoinLiveness';

--- a/src/hooks/useJoinLiveness.ts
+++ b/src/hooks/useJoinLiveness.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react';
+
+export type JoinLiveness = 'live' | 'pending' | 'ended';
+
+/**
+ * Tracks whether a joined session is still backed by a live operator session, with
+ * a grace window before declaring it gone.
+ *
+ * A `mirrord` session frequently disappears from the operator's list for a few
+ * seconds when the user's local process reconnects (stop → start): the old session
+ * is torn down and a new one — same key, new id — takes its place. Flipping the
+ * banner straight to "ended" in that gap left users staring at a "Dismiss" prompt
+ * for a session that had already come back.
+ *
+ * Liveness is keyed on the session *key*, not the specific session id, so a
+ * reconnect that reuses the key counts as live. When no session currently holds the
+ * key we don't dismiss immediately: we hold a `pending` (warning) state for
+ * `graceMs`, and only settle on `ended` if nothing reclaims the key within that
+ * window. If the key goes live again at any point, we snap back to `live`.
+ */
+export function useJoinLiveness(
+    joined: boolean,
+    live: boolean,
+    graceMs: number
+): JoinLiveness {
+    const [expired, setExpired] = useState(false);
+
+    useEffect(() => {
+        if (!joined || live) {
+            setExpired(false);
+            return;
+        }
+        const timer = setTimeout(() => setExpired(true), graceMs);
+        return () => clearTimeout(timer);
+    }, [joined, live, graceMs]);
+
+    if (live) return 'live';
+    return expired ? 'ended' : 'pending';
+}

--- a/src/hooks/useMirrordUi.ts
+++ b/src/hooks/useMirrordUi.ts
@@ -134,7 +134,6 @@ function groupByKey(
 export type JoinState = {
     joinedKey: string | null;
     joinedSessionName: string | null;
-    sessionEnded: boolean;
 };
 
 export function useMirrordUi() {
@@ -157,7 +156,6 @@ export function useMirrordUi() {
     const [joinState, setJoinState] = useState<JoinState>({
         joinedKey: null,
         joinedSessionName: null,
-        sessionEnded: false,
     });
     const [scopePatterns, setScopePatternsState] = useState<string[]>([]);
     const [joinedHeader, setJoinedHeader] = useState<string | null>(null);
@@ -189,7 +187,6 @@ export function useMirrordUi() {
                 joinedSessionName:
                     (stored[STORAGE_KEYS.JOINED_SESSION_NAME] as string) ??
                     null,
-                sessionEnded: false,
             });
             const header =
                 (stored[STORAGE_KEYS.JOINED_HEADER] as string) ?? null;
@@ -297,15 +294,6 @@ export function useMirrordUi() {
             setSessions((current) =>
                 current ? applyNotification(current, msg) : current
             );
-            if (
-                msg.type === SESSION_NOTIFICATION_TYPE.OPERATOR_SESSION_REMOVED
-            ) {
-                setJoinState((js) =>
-                    js.joinedSessionName === msg.id
-                        ? { ...js, sessionEnded: true }
-                        : js
-                );
-            }
         };
         ws.onerror = () => setError(STRINGS.ERR_WS_CONNECTION);
         ws.onclose = () => {
@@ -362,7 +350,6 @@ export function useMirrordUi() {
             setJoinState({
                 joinedKey: key,
                 joinedSessionName: target.id,
-                sessionEnded: false,
             });
         },
         [sessions, scopePatterns]
@@ -389,7 +376,6 @@ export function useMirrordUi() {
         setJoinState({
             joinedKey: null,
             joinedSessionName: null,
-            sessionEnded: false,
         });
     }, []);
 


### PR DESCRIPTION
## Problem

When a joined `mirrord` session stops and comes back (stop → start), the joined-session banner stayed stuck on the red **"Session ended" / Dismiss** state even though a live session for the same key was already back.

The banner tracked liveness by the **specific operator session id** (`joinedSessionName`). A reconnect reissues a *new* id for the *same key*, so the old id never re-matched and a sticky `sessionEnded` flag (set on the WS `OPERATOR_SESSION_REMOVED` event) kept the banner in the ended state.

## Fix

- **Liveness is now keyed on the session `key`, not the id.** A reconnect that reclaims the key counts as live, so the banner rides through it. Removed the sticky id-based `sessionEnded` flag and its WS handler.
- **Added an amber grace state.** New `useJoinLiveness` hook returns `live | pending | ended`:
  - a session holds the key → green **"Session live"**
  - no session holds the key → amber **"Waiting for session"** (injection still active, Leave still available)
  - still no match after `JOIN_GRACE_MS` (60s) → red **"Session ended" / Dismiss**
  - key goes live again during the window → snaps back to live.

## Tests

- `jest` — 183 passing. Rewrote the old id-based "session ended" test into two: one proving the banner stays live through a reconnect (new id, same key), one proving amber → ended after advancing fake timers past the 60s grace.
- `tsc`, `eslint`, `prettier` clean on the changed files.