### PR TITLE
Add kube context selector via mirrord ui v2 (with v1 fallback)

### DIFF
--- a/changelog.d/+context-selector.added.md
+++ b/changelog.d/+context-selector.added.md
@@ -1,0 +1,1 @@
+Added a kube context selector to the popup. When the `mirrord ui` server supports it, you can pick which cluster context's sessions to view (and still filter by namespace); older servers keep working unchanged.

--- a/src/__tests__/SessionsView.test.tsx
+++ b/src/__tests__/SessionsView.test.tsx
@@ -2,7 +2,11 @@
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import React from 'react';
-import type { OperatorSessionSummary, OperatorWatchStatus } from '../types';
+import type {
+    KubeContext,
+    OperatorSessionSummary,
+    OperatorWatchStatus,
+} from '../types';
 
 jest.mock('@metalbear/ui', () => ({
     Card: ({
@@ -113,6 +117,10 @@ describe('SessionsView', () => {
         namespaces: ['', 'ns-a', 'ns-b'],
         namespace: '',
         setNamespace: jest.fn(),
+        contexts: [] as KubeContext[],
+        currentContext: null as string | null,
+        selectedContext: null as string | null,
+        onSelectContext: jest.fn(),
         joinState: {
             joinedKey: null,
             joinedSessionName: null,

--- a/src/__tests__/useMirrordUi.test.ts
+++ b/src/__tests__/useMirrordUi.test.ts
@@ -1,5 +1,9 @@
 import { renderHook, act, waitFor } from '@testing-library/react';
-import { useMirrordUi } from '../hooks/useMirrordUi';
+import {
+    useMirrordUi,
+    fetchContexts,
+    fetchOperatorSessionsV2,
+} from '../hooks/useMirrordUi';
 import type { OperatorSessionsResponse } from '../types';
 import { STORAGE_KEYS } from '../types';
 import { decodeConfig } from '../config';
@@ -408,5 +412,102 @@ test('session share uses the operator HTTP filter when it can derive a header', 
     expect(payload).toBeTruthy();
     expect(decodeConfig(payload!)).toEqual({
         header_filter: 'x-tenant: alice',
+    });
+});
+
+describe('v2 API', () => {
+    const makeResp = (body: string, status = 200) =>
+        ({
+            ok: status >= 200 && status < 300,
+            status,
+            statusText: 'OK',
+            text: () => Promise.resolve(body),
+            json: () => Promise.resolve(JSON.parse(body)),
+        }) as unknown as Response;
+
+    const mockFetch = (impl: (url: string) => Response) =>
+        jest.fn((url: RequestInfo | URL) =>
+            Promise.resolve(impl(String(url)))
+        ) as unknown as typeof fetch;
+
+    test('fetchContexts returns null on 404 (server without v2)', async () => {
+        const f = mockFetch(() => makeResp('', 404));
+        await expect(fetchContexts('http://b', 't', f)).resolves.toBeNull();
+    });
+
+    test('fetchContexts parses the context list on success', async () => {
+        const body = JSON.stringify({
+            current: 'ctx-a',
+            contexts: [
+                { name: 'ctx-a', namespace: 'default' },
+                { name: 'ctx-b', namespace: null },
+            ],
+        });
+        const f = mockFetch(() => makeResp(body));
+        const r = await fetchContexts('http://b', 't', f);
+        expect(r?.current).toBe('ctx-a');
+        expect(r?.contexts.map((c) => c.name)).toEqual(['ctx-a', 'ctx-b']);
+    });
+
+    test('fetchOperatorSessionsV2 maps the v2 shape to the internal one', async () => {
+        const v2 = {
+            context: 'ctx-a',
+            status: 'available',
+            sessions: [
+                {
+                    id: 'a',
+                    key: 'k1',
+                    namespace: 'ns-a',
+                    owner,
+                    target: null,
+                    createdAt,
+                },
+                {
+                    id: 'b',
+                    key: 'k1',
+                    namespace: 'ns-b',
+                    owner,
+                    target: null,
+                    createdAt,
+                },
+            ],
+        };
+        const f = mockFetch(() => makeResp(JSON.stringify(v2)));
+        const r = await fetchOperatorSessionsV2('http://b', 't', 'ctx-a', f);
+        expect(r.sessions).toHaveLength(2);
+        expect(Object.keys(r.by_key)).toEqual(['k1']);
+        expect(r.watch_status).toEqual({ status: 'watching' });
+    });
+
+    test('fetchOperatorSessionsV2 maps an unavailable operator with its reason', async () => {
+        const v2 = {
+            context: null,
+            status: 'unavailable',
+            reason: 'operator not available',
+            sessions: [],
+        };
+        const f = mockFetch(() => makeResp(JSON.stringify(v2)));
+        const r = await fetchOperatorSessionsV2('http://b', 't', null, f);
+        expect(r.watch_status).toEqual({
+            status: 'unavailable',
+            reason: 'operator not available',
+        });
+    });
+
+    test('fetchOperatorSessionsV2 sends the selected context as a query param', async () => {
+        const f = mockFetch(() =>
+            makeResp(
+                JSON.stringify({
+                    context: 'ctx-a',
+                    status: 'available',
+                    sessions: [],
+                })
+            )
+        );
+        await fetchOperatorSessionsV2('http://b', 'tok', 'ctx-a', f);
+        const calledUrl = String((f as jest.Mock).mock.calls[0][0]);
+        expect(calledUrl).toContain('/api/v2/operator/sessions');
+        expect(calledUrl).toContain('context=ctx-a');
+        expect(calledUrl).toContain('token=tok');
     });
 });

--- a/src/components/ContextFilter.tsx
+++ b/src/components/ContextFilter.tsx
@@ -38,7 +38,6 @@ export function ContextFilter({
                     height: 32,
                     fontSize: 11,
                     minWidth: 120,
-                    maxWidth: 190,
                     flex: 1,
                 }}
                 aria-label={`Filter by ${STRINGS.LABEL_CONTEXT.toLowerCase()}`}

--- a/src/components/ContextFilter.tsx
+++ b/src/components/ContextFilter.tsx
@@ -34,11 +34,30 @@ export function ContextFilter({
         <Select value={selected} onValueChange={onChange}>
             <SelectTrigger
                 id="ctx-select"
-                className="font-mono"
-                style={{ height: 32, fontSize: 11, width: 130, flexShrink: 0 }}
+                style={{
+                    height: 32,
+                    fontSize: 11,
+                    minWidth: 120,
+                    maxWidth: 190,
+                    flex: 1,
+                }}
                 aria-label={`Filter by ${STRINGS.LABEL_CONTEXT.toLowerCase()}`}
             >
-                <SelectValue />
+                <span
+                    className="text-muted-foreground"
+                    style={{
+                        fontSize: 9,
+                        textTransform: 'uppercase',
+                        letterSpacing: 0.5,
+                        marginRight: 6,
+                        flexShrink: 0,
+                    }}
+                >
+                    {STRINGS.LABEL_CONTEXT}
+                </span>
+                <span className="font-mono" style={{ minWidth: 0 }}>
+                    <SelectValue />
+                </span>
             </SelectTrigger>
             <SelectContent>
                 {contexts.map((ctx) => (

--- a/src/components/ContextFilter.tsx
+++ b/src/components/ContextFilter.tsx
@@ -1,0 +1,54 @@
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@metalbear/ui';
+import { STRINGS } from '../constants';
+import type { KubeContext } from '../types';
+
+type Props = {
+    contexts: KubeContext[];
+    currentContext: string | null;
+    // The context whose sessions are shown; falls back to `currentContext` when unset.
+    value: string | null;
+    onChange: (context: string) => void;
+};
+
+/**
+ * Selects which kube context's operator sessions to show. Only rendered when the `mirrord ui` server
+ * supports `/api/v2` and more than one context exists (see `useMirrordUi`).
+ */
+export function ContextFilter({
+    contexts,
+    currentContext,
+    value,
+    onChange,
+}: Props) {
+    if (contexts.length <= 1) return null;
+
+    const selected = value ?? currentContext ?? contexts[0]?.name ?? '';
+
+    return (
+        <Select value={selected} onValueChange={onChange}>
+            <SelectTrigger
+                id="ctx-select"
+                className="font-mono"
+                style={{ height: 32, fontSize: 11, width: 130, flexShrink: 0 }}
+                aria-label={`Filter by ${STRINGS.LABEL_CONTEXT.toLowerCase()}`}
+            >
+                <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+                {contexts.map((ctx) => (
+                    <SelectItem key={ctx.name} value={ctx.name}>
+                        {ctx.name === currentContext
+                            ? `${ctx.name} (current)`
+                            : ctx.name}
+                    </SelectItem>
+                ))}
+            </SelectContent>
+        </Select>
+    );
+}

--- a/src/components/NamespaceFilter.tsx
+++ b/src/components/NamespaceFilter.tsx
@@ -28,11 +28,30 @@ export function NamespaceFilter({ namespaces, value, onChange }: Props) {
         >
             <SelectTrigger
                 id="ns-select"
-                className="font-mono"
-                style={{ height: 32, fontSize: 11, width: 110, flexShrink: 0 }}
+                style={{
+                    height: 32,
+                    fontSize: 11,
+                    minWidth: 120,
+                    maxWidth: 190,
+                    flex: 1,
+                }}
                 aria-label={`Filter by ${STRINGS.LABEL_NAMESPACE.toLowerCase()}`}
             >
-                <SelectValue />
+                <span
+                    className="text-muted-foreground"
+                    style={{
+                        fontSize: 9,
+                        textTransform: 'uppercase',
+                        letterSpacing: 0.5,
+                        marginRight: 6,
+                        flexShrink: 0,
+                    }}
+                >
+                    {STRINGS.LABEL_NAMESPACE}
+                </span>
+                <span className="font-mono" style={{ minWidth: 0 }}>
+                    <SelectValue />
+                </span>
             </SelectTrigger>
             <SelectContent>
                 <SelectItem value={NAMESPACE_ALL_SENTINEL}>

--- a/src/components/NamespaceFilter.tsx
+++ b/src/components/NamespaceFilter.tsx
@@ -32,7 +32,6 @@ export function NamespaceFilter({ namespaces, value, onChange }: Props) {
                     height: 32,
                     fontSize: 11,
                     minWidth: 120,
-                    maxWidth: 190,
                     flex: 1,
                 }}
                 aria-label={`Filter by ${STRINGS.LABEL_NAMESPACE.toLowerCase()}`}

--- a/src/components/SessionsView.tsx
+++ b/src/components/SessionsView.tsx
@@ -134,7 +134,6 @@ export function SessionsView({
         ? sessions.filter((s) => s.key === joinedKey)
         : [];
 
-    const hasNamespaces = namespaces.filter((ns) => ns !== '').length > 0;
     const watching = status?.status === 'watching';
     const operatorUnavailable = status?.status === 'unavailable';
     const hasGroups = orderedKeys.length > 0;
@@ -169,13 +168,19 @@ export function SessionsView({
 
             {operatorUnavailable && <OperatorUnavailableNote />}
 
-            {contexts.length > 1 && (
-                <div className="flex items-center" style={{ gap: 8 }}>
+            {(contexts.length > 1 ||
+                namespaces.filter((ns) => ns !== '').length > 1) && (
+                <div className="flex items-center flex-wrap" style={{ gap: 8 }}>
                     <ContextFilter
                         contexts={contexts}
                         currentContext={currentContext}
                         value={selectedContext}
                         onChange={onSelectContext}
+                    />
+                    <NamespaceFilter
+                        namespaces={namespaces}
+                        value={namespace}
+                        onChange={setNamespace}
                     />
                 </div>
             )}
@@ -215,13 +220,6 @@ export function SessionsView({
                             }}
                         />
                     </div>
-                    {hasNamespaces && (
-                        <NamespaceFilter
-                            namespaces={namespaces}
-                            value={namespace}
-                            onChange={setNamespace}
-                        />
-                    )}
                 </div>
             )}
 

--- a/src/components/SessionsView.tsx
+++ b/src/components/SessionsView.tsx
@@ -5,6 +5,7 @@ import { Input } from '@metalbear/ui';
 import { SessionKeyGroup } from './SessionKeyGroup';
 import { ConnectedBanner } from './ConnectedBanner';
 import { NamespaceFilter } from './NamespaceFilter';
+import { ContextFilter } from './ContextFilter';
 import { StatusDot } from './StatusDot';
 import { NotConfiguredPrompt } from './NotConfiguredPrompt';
 import { MirrordUiDetectedPrompt } from './MirrordUiDetectedPrompt';
@@ -12,7 +13,11 @@ import { MirrordUiAuthError } from './MirrordUiAuthError';
 import { OperatorUnavailableNote } from './OperatorUnavailableNote';
 import type { JoinState } from '../hooks/useMirrordUi';
 import { useJoinLiveness } from '../hooks/useJoinLiveness';
-import type { OperatorSessionSummary, OperatorWatchStatus } from '../types';
+import type {
+    KubeContext,
+    OperatorSessionSummary,
+    OperatorWatchStatus,
+} from '../types';
 import { JOIN_GRACE_MS, STRINGS } from '../constants';
 
 type Props = {
@@ -24,6 +29,10 @@ type Props = {
     namespaces: string[];
     namespace: string;
     setNamespace: (ns: string) => void;
+    contexts: KubeContext[];
+    currentContext: string | null;
+    selectedContext: string | null;
+    onSelectContext: (context: string) => void;
     joinState: JoinState;
     status: OperatorWatchStatus | null;
     onJoin: (key: string) => void;
@@ -62,6 +71,10 @@ export function SessionsView({
     namespaces,
     namespace,
     setNamespace,
+    contexts,
+    currentContext,
+    selectedContext,
+    onSelectContext,
     joinState,
     status,
     onJoin,
@@ -155,6 +168,17 @@ export function SessionsView({
             )}
 
             {operatorUnavailable && <OperatorUnavailableNote />}
+
+            {contexts.length > 1 && (
+                <div className="flex items-center" style={{ gap: 8 }}>
+                    <ContextFilter
+                        contexts={contexts}
+                        currentContext={currentContext}
+                        value={selectedContext}
+                        onChange={onSelectContext}
+                    />
+                </div>
+            )}
 
             {showSearch && (
                 <div className="flex items-center" style={{ gap: 8 }}>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,6 +8,7 @@ export const STRINGS = {
     LABEL_HEADER_VALUE: 'Header Value',
     LABEL_URL_SCOPE: 'URL Scope',
     LABEL_NAMESPACE: 'Namespace',
+    LABEL_CONTEXT: 'Context',
 
     PLACEHOLDER_HEADER_NAME: 'X-MIRRORD-USER',
     PLACEHOLDER_HEADER_VALUE: 'testuser',

--- a/src/hooks/useMirrordUi.ts
+++ b/src/hooks/useMirrordUi.ts
@@ -3,8 +3,11 @@ import groupBy from 'lodash.groupby';
 import { STORAGE_KEYS } from '../types';
 import type {
     Config,
+    ContextsResponse,
+    KubeContext,
     OperatorSessionSummary,
     OperatorSessionsResponse,
+    OperatorSessionsV2Response,
     OperatorWatchStatus,
     SessionNotification,
 } from '../types';
@@ -44,16 +47,81 @@ export async function fetchOperatorSessions(
     return (await resp.json()) as OperatorSessionsResponse;
 }
 
+/**
+ * Fetches the kube contexts from the v2 API, which doubles as a probe for whether the `mirrord ui`
+ * server supports `/api/v2` at all. Returns `null` on 404 (an older server without v2), the context
+ * list on success, and throws on other errors (e.g. auth failures).
+ */
+export async function fetchContexts(
+    backend: string,
+    token: string,
+    fetchImpl: typeof fetch = fetch
+): Promise<ContextsResponse | null> {
+    const url = `${backend}/api/v2/kube/contexts?token=${encodeURIComponent(token)}`;
+    const resp = await fetchImpl(url);
+    if (resp.status === 404) return null;
+    if (!resp.ok) {
+        const e = new Error(
+            `mirrord ui responded ${resp.status} ${resp.statusText}`
+        );
+        (e as Error & { status?: number }).status = resp.status;
+        throw e;
+    }
+    return (await resp.json()) as ContextsResponse;
+}
+
+function mapV2ToInternal(
+    v2: OperatorSessionsV2Response
+): OperatorSessionsResponse {
+    const watch_status: OperatorWatchStatus =
+        v2.status === 'available'
+            ? { status: 'watching' }
+            : { status: 'unavailable', reason: v2.reason ?? '' };
+    return {
+        sessions: v2.sessions,
+        by_key: groupByKey(v2.sessions),
+        watch_status,
+    };
+}
+
+/**
+ * Fetches operator sessions for a specific kube context via the v2 API. Namespace filtering stays
+ * client-side (the response carries every namespace's sessions), so no namespace param is sent.
+ */
+export async function fetchOperatorSessionsV2(
+    backend: string,
+    token: string,
+    context: string | null,
+    fetchImpl: typeof fetch = fetch
+): Promise<OperatorSessionsResponse> {
+    const params = new URLSearchParams({ token });
+    if (context) params.set('context', context);
+    const url = `${backend}/api/v2/operator/sessions?${params.toString()}`;
+    const resp = await fetchImpl(url);
+    if (!resp.ok) {
+        const e = new Error(
+            `mirrord ui responded ${resp.status} ${resp.statusText}: ${await resp.text()}`
+        );
+        (e as Error & { status?: number }).status = resp.status;
+        throw e;
+    }
+    return mapV2ToInternal((await resp.json()) as OperatorSessionsV2Response);
+}
+
 export type PollResult =
     | { ok: true; data: OperatorSessionsResponse }
     | { ok: false; status?: number; error: string };
 
 export async function runPoll(
     backend: string,
-    token: string
+    token: string,
+    v2 = false,
+    context: string | null = null
 ): Promise<PollResult> {
     try {
-        const resp = await fetchOperatorSessions(backend, token);
+        const resp = v2
+            ? await fetchOperatorSessionsV2(backend, token, context)
+            : await fetchOperatorSessions(backend, token);
         if (!bridgeHealthy) {
             bridgeHealthy = true;
             emitUserSucceeded('bridge_recovered', 'health');
@@ -117,6 +185,7 @@ const WATCHED_STORAGE_KEYS: readonly string[] = [
     STORAGE_KEYS.SCOPE_PATTERNS,
     STORAGE_KEYS.MIRRORD_UI_BACKEND,
     STORAGE_KEYS.MIRRORD_UI_TOKEN,
+    STORAGE_KEYS.SELECTED_CONTEXT,
 ];
 
 function hasWatchedChange(
@@ -153,6 +222,14 @@ export function useMirrordUi() {
     // another process on the port. Surfaced separately so the UI can tell the user to re-auth.
     const [authFailed, setAuthFailed] = useState(false);
     const [namespace, setNamespace] = useState<string>('');
+    // `null` while probing; `true`/`false` once we know if the server has `/api/v2`. Determines
+    // whether context selection is available and whether we poll v2 or fall back to v1.
+    const [v2Available, setV2Available] = useState<boolean | null>(null);
+    const [contexts, setContexts] = useState<KubeContext[]>([]);
+    const [currentContext, setCurrentContext] = useState<string | null>(null);
+    const [selectedContext, setSelectedContextState] = useState<string | null>(
+        null
+    );
     const [joinState, setJoinState] = useState<JoinState>({
         joinedKey: null,
         joinedSessionName: null,
@@ -165,6 +242,9 @@ export function useMirrordUi() {
 
     const wsRef = useRef<WebSocket | null>(null);
 
+    // The context whose sessions we show: the user's pick, else the kubeconfig's current context.
+    const effectiveContext = selectedContext ?? currentContext;
+
     useEffect(() => {
         let cancelled = false;
         const loadFromStorage = async () => {
@@ -176,6 +256,7 @@ export function useMirrordUi() {
                 STORAGE_KEYS.JOINED_HEADER,
                 STORAGE_KEYS.JOINED_VALUE,
                 STORAGE_KEYS.SCOPE_PATTERNS,
+                STORAGE_KEYS.SELECTED_CONTEXT,
             ]);
             if (cancelled) return;
             setBackend(
@@ -202,6 +283,9 @@ export function useMirrordUi() {
                           (p) => typeof p === 'string'
                       )
                     : []
+            );
+            setSelectedContextState(
+                (stored[STORAGE_KEYS.SELECTED_CONTEXT] as string) ?? null
             );
             setConfigLoaded(true);
         };
@@ -253,21 +337,56 @@ export function useMirrordUi() {
         };
     }, [configLoaded, token]);
 
+    // Probe for `/api/v2`: its presence enables context selection, its absence falls back to v1.
     useEffect(() => {
-        if (!backend || !token || healthy !== true) return;
+        if (!backend || !token || healthy !== true) {
+            setV2Available(null);
+            return;
+        }
         let cancelled = false;
-        const refresh = () => {
-            runPoll(backend, token).then((result) => {
+        fetchContexts(backend, token)
+            .then((resp) => {
                 if (cancelled) return;
-                if (result.ok) {
-                    setSessions(result.data);
-                    setStatus(result.data.watch_status);
-                    setError(null);
-                    setAuthFailed(false);
-                } else {
-                    setAuthFailed(isAuthFailureStatus(result.status));
+                if (resp === null) {
+                    setV2Available(false);
+                    setContexts([]);
+                    return;
+                }
+                setV2Available(true);
+                setContexts(resp.contexts);
+                setCurrentContext(resp.current);
+            })
+            .catch(() => {
+                // A non-404 failure (e.g. bad token) — fall back to v1, whose poll surfaces the
+                // auth error. Re-probes when backend/token/health change.
+                if (!cancelled) {
+                    setV2Available(false);
+                    setContexts([]);
                 }
             });
+        return () => {
+            cancelled = true;
+        };
+    }, [backend, token, healthy]);
+
+    useEffect(() => {
+        if (!backend || !token || healthy !== true || v2Available === null)
+            return;
+        let cancelled = false;
+        const refresh = () => {
+            runPoll(backend, token, v2Available, effectiveContext).then(
+                (result) => {
+                    if (cancelled) return;
+                    if (result.ok) {
+                        setSessions(result.data);
+                        setStatus(result.data.watch_status);
+                        setError(null);
+                        setAuthFailed(false);
+                    } else {
+                        setAuthFailed(isAuthFailureStatus(result.status));
+                    }
+                }
+            );
         };
         refresh();
         const interval = setInterval(refresh, OPERATOR_SESSIONS_POLL_MS);
@@ -275,10 +394,13 @@ export function useMirrordUi() {
             cancelled = true;
             clearInterval(interval);
         };
-    }, [backend, token, healthy]);
+    }, [backend, token, healthy, v2Available, effectiveContext]);
 
+    // The live-updates WebSocket is a v1-only feature; v2 is poll-only (its `/api/v2/operator/
+    // sessions` is per-context and has no push channel), so only open it on the v1 fallback path.
     useEffect(() => {
-        if (!backend || !token || healthy !== true) return;
+        if (!backend || !token || healthy !== true || v2Available !== false)
+            return;
         const url = buildWsUrl(backend, token);
         const ws = new WebSocket(url);
         wsRef.current = ws;
@@ -304,7 +426,7 @@ export function useMirrordUi() {
             ws.close();
             wsRef.current = null;
         };
-    }, [backend, token, healthy]);
+    }, [backend, token, healthy, v2Available]);
 
     const namespaces = useMemo(() => {
         const set = new Set<string>();
@@ -421,6 +543,11 @@ export function useMirrordUi() {
         [sessions]
     );
 
+    const setSelectedContext = useCallback(async (context: string) => {
+        await storageSet({ [STORAGE_KEYS.SELECTED_CONTEXT]: context });
+        setSelectedContextState(context);
+    }, []);
+
     return {
         backend,
         healthy,
@@ -432,6 +559,11 @@ export function useMirrordUi() {
         namespaces,
         namespace,
         setNamespace,
+        v2Available,
+        contexts,
+        currentContext,
+        selectedContext,
+        setSelectedContext,
         groupedFiltered,
         joinState,
         joinedHeader,

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -204,6 +204,10 @@ function SessionsScreen({
             namespaces={mirrordUi.namespaces}
             namespace={mirrordUi.namespace}
             setNamespace={mirrordUi.setNamespace}
+            contexts={mirrordUi.contexts}
+            currentContext={mirrordUi.currentContext}
+            selectedContext={mirrordUi.selectedContext}
+            onSelectContext={mirrordUi.setSelectedContext}
             joinState={mirrordUi.joinState}
             status={mirrordUi.status}
             onJoin={mirrordUi.join}

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,7 @@ export const STORAGE_KEYS = {
     SCOPE_PATTERNS: 'scope_patterns',
     ACTIVE_TAB: 'active_tab',
     THEME: 'theme',
+    SELECTED_CONTEXT: 'selected_context',
 } as const;
 
 export type ThemePref = 'system' | 'light' | 'dark';
@@ -77,6 +78,26 @@ export type OperatorSessionsResponse = {
     by_key: Record<string, OperatorSessionSummary[]>;
     sessions: OperatorSessionSummary[];
     watch_status: OperatorWatchStatus;
+};
+
+// A kube context and its default namespace, from `GET /api/v2/kube/contexts`.
+export type KubeContext = {
+    name: string;
+    namespace: string | null;
+};
+
+export type ContextsResponse = {
+    current: string | null;
+    contexts: KubeContext[];
+};
+
+// `GET /api/v2/operator/sessions?context=`. Namespace is filtered client-side, so this doesn't take
+// a namespace param. `OperatorSession` is the same shape the extension already uses for a summary.
+export type OperatorSessionsV2Response = {
+    context: string | null;
+    status: 'available' | 'unavailable';
+    reason?: string;
+    sessions: OperatorSessionSummary[];
 };
 
 export type SessionNotification =


### PR DESCRIPTION
## What

Adds a **kube context selector** to the extension popup, mirroring the new context/namespace support in the `mirrord ui`.

## How

- **Probes for v2**: fetches `/api/v2/kube/contexts`. If present, the extension is context-aware; if it 404s (older `mirrord ui` server), it **falls back to the existing v1 path** (`/api/operator-sessions` + the live `/ws`), so nothing breaks for users on an older mirrord.
- **v2 path**: polls `/api/v2/operator/sessions?context=` for the selected context, mapping the v2 response (`{context, status, reason?, sessions}`) to the internal `OperatorSessionsResponse` (builds `by_key`, maps `status` → `watch_status`). v2 is poll-only, so the WebSocket is only used on the v1 fallback.
- **UI**: a context dropdown appears (above the search/namespace row, so it's usable even when the current context has no sessions) when the server is v2 and more than one context exists. The selection persists in `chrome.storage`.
- **Namespace** filtering stays client-side, derived from the visible sessions — unchanged.

## Testing

- `tsc` clean on `src`; eslint + prettier clean.
- 49 unit tests pass (added 5 for the v2 helpers: `fetchContexts` 404→null / parse, `fetchOperatorSessionsV2` shape mapping / status / context param). The existing suite already exercises the v1 fallback (its fetch mock rejects the v2 probe).
- `vite build` succeeds.

## Depends on

The `mirrord` PR that adds `/api/v2` (metalbear-co/mirrord#4508). The v1 fallback means this can ship independently, but context selection only lights up against a mirrord server that has v2.
