### PR TITLE
ci: gate the TypeScript compiler in check

### DIFF
--- a/changelog.d/+gate-typecheck.internal.md
+++ b/changelog.d/+gate-typecheck.internal.md
@@ -1,0 +1,1 @@
+The CI check gate now also runs the TypeScript compiler, so type errors fail pull requests alongside lint and formatting.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
         "format:check": "prettier --check .",
         "lint": "eslint . --ext .ts,.tsx",
         "lint:fix": "eslint . --ext .ts,.tsx --fix",
-        "check": "pnpm run format:check && pnpm run lint",
+        "typecheck": "tsc --noEmit",
+        "check": "pnpm run format:check && pnpm run lint && pnpm run typecheck",
         "test:e2e": "playwright test",
         "test:e2e:ui": "playwright test --ui",
         "prepare": "husky"


### PR DESCRIPTION
## Summary

The CI `check` gate ran `format:check` and `lint` but never the TypeScript compiler, so type errors could land on main unnoticed (the strict shared tsconfig from the uikit adoption is only enforced at editor level today). Adds a `typecheck` script (`tsc --noEmit`) and chains it into `check`, which CI already runs on every PR.

## Test plan

- [x] `pnpm run check` passes locally on main (format + lint + tsc, 0 errors).
- [x] No workflow changes needed — CI already runs `pnpm run check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)