### PR TITLE
feat: report unhandled errors to error tracking

### DIFF
--- a/changelog.d/+error-tracking.internal.md
+++ b/changelog.d/+error-tracking.internal.md
@@ -1,0 +1,1 @@
+The extension now reports unhandled errors and crash-screen exceptions to our product analytics (respecting the existing analytics opt-out), so extension errors in the wild surface in error tracking.

--- a/src/__tests__/applied.test.tsx
+++ b/src/__tests__/applied.test.tsx
@@ -3,6 +3,7 @@ jest.mock('../analytics', () => ({
     capture: jest.fn(),
     emitUserBlocked: jest.fn(),
     emitUserSucceeded: jest.fn(),
+    initErrorTracking: jest.fn(),
 }));
 // joinMatchingSession's internals are covered by config.test; here we control its result to
 // exercise run()'s join-vs-static-override orchestration.

--- a/src/__tests__/popup.test.tsx
+++ b/src/__tests__/popup.test.tsx
@@ -9,6 +9,7 @@ jest.mock('../analytics', () => ({
     optOutReady: Promise.resolve(),
     emitUserBlocked: jest.fn(),
     emitUserSucceeded: jest.fn(),
+    initErrorTracking: jest.fn(),
 }));
 
 jest.mock('../headerObservation', () => {

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -110,6 +110,35 @@ export function captureBeacon(
     }
 }
 
+export function captureException(
+    error: unknown,
+    properties: Record<string, unknown> = {},
+    handled = true
+): void {
+    const err = error instanceof Error ? error : new Error(String(error));
+    capture('$exception', {
+        $exception_list: [
+            {
+                type: err.name,
+                value: err.message,
+                mechanism: { handled, synthetic: false },
+            },
+        ],
+        $exception_stack_trace_raw: err.stack,
+        surface: 'extension',
+        ...properties,
+    });
+}
+
+export function initErrorTracking(page: string): void {
+    window.addEventListener('error', (event) => {
+        captureException(event.error ?? event.message, { page }, false);
+    });
+    window.addEventListener('unhandledrejection', (event) => {
+        captureException(event.reason, { page }, false);
+    });
+}
+
 export type EventKind = 'user_action' | 'health';
 
 export function emitUserBlocked(

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -3,6 +3,14 @@ import { STORAGE_KEYS } from './types';
 const POSTHOG_KEY = 'phc_wIZh92nyk4vu6HidiLFUzjW6piZlZszuWZZFBS7yHHe';
 const POSTHOG_HOST = 'https://hog.metalbear.com';
 
+const APP_VERSION = (() => {
+    try {
+        return chrome.runtime.getManifest().version;
+    } catch {
+        return 'unknown';
+    }
+})();
+
 let distinctId: string | null = null;
 let optedOut = false;
 
@@ -74,6 +82,7 @@ export function capture(
                 properties: {
                     ...properties,
                     $lib: 'mirrord-browser-extension',
+                    $app_version: APP_VERSION,
                 },
                 timestamp: new Date().toISOString(),
             }),
@@ -101,6 +110,7 @@ export function captureBeacon(
             properties: {
                 ...properties,
                 $lib: 'mirrord-browser-extension',
+                $app_version: APP_VERSION,
             },
             timestamp: new Date().toISOString(),
         });

--- a/src/applied.tsx
+++ b/src/applied.tsx
@@ -14,8 +14,15 @@ import {
 } from './configCore';
 import { applyHeaderConfig } from './applyConfig';
 import { joinMatchingSession } from './joinSession';
-import { capture, emitUserBlocked, emitUserSucceeded } from './analytics';
+import {
+    capture,
+    emitUserBlocked,
+    emitUserSucceeded,
+    initErrorTracking,
+} from './analytics';
 import { STRINGS } from './constants';
+
+initErrorTracking('applied');
 
 export type AppliedState =
     | { kind: 'loading' }

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 import { ErrorBoundary as KitErrorBoundary } from '@metalbear/ui';
-import { emitUserBlocked } from '../analytics';
+import { captureException, emitUserBlocked } from '../analytics';
 import { STRINGS } from '../constants';
 
 type Flow = 'session_monitor' | 'header_injector' | 'configure';
@@ -23,6 +23,14 @@ export function ErrorBoundary({ flow, component, children }: Props) {
                 </div>
             }
             onError={(error, info) => {
+                captureException(error, {
+                    component,
+                    flow,
+                    componentStack: info.componentStack?.slice(
+                        0,
+                        MAX_STACK_LENGTH
+                    ),
+                });
                 emitUserBlocked('ui_crashed', 'user_action', {
                     error: error.message,
                     component,

--- a/src/configure.tsx
+++ b/src/configure.tsx
@@ -8,7 +8,7 @@ import { Card, CardContent } from '@metalbear/ui';
 
 initTheme();
 import { STORAGE_KEYS } from './types';
-import { capture } from './analytics';
+import { capture, initErrorTracking } from './analytics';
 import { fetchOperatorSessions } from './hooks/useMirrordUi';
 import {
     buildDnrRule,
@@ -22,6 +22,8 @@ import {
     STRINGS,
     type ConfigureStatusKind,
 } from './constants';
+
+initErrorTracking('configure');
 
 type Status =
     | { kind: typeof CONFIGURE_STATUS.LOADING }

--- a/src/options.tsx
+++ b/src/options.tsx
@@ -6,8 +6,10 @@ import './tokens.css';
 import { initTheme } from './theme';
 import { Label, Switch } from '@metalbear/ui';
 import { STRINGS } from './constants';
-import { optOutReady, setOptOut } from './analytics';
+import { optOutReady, setOptOut, initErrorTracking } from './analytics';
 import { STORAGE_KEYS } from './types';
+
+initErrorTracking('options');
 
 initTheme();
 

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -21,9 +21,16 @@ import type { ThemePref } from './types';
 import { SessionsView, ManualSetup } from './components';
 import { useHeaderRules } from './hooks';
 import { useMirrordUi } from './hooks/useMirrordUi';
-import { capture, captureBeacon, optOutReady } from './analytics';
+import {
+    capture,
+    captureBeacon,
+    optOutReady,
+    initErrorTracking,
+} from './analytics';
 import { STRINGS, TAB, type TabId } from './constants';
 import { STORAGE_KEYS } from './types';
+
+initErrorTracking('popup');
 
 const popupOpenedAt = Date.now();
 const surface: 'side_panel' | 'popup_fallback' =


### PR DESCRIPTION
## Summary

The extension has product analytics but no exception reporting, so errors in the wild are invisible unless a user reports them. The extension uses a hand-rolled capture pipeline (no PostHog SDK, MV3-friendly), so this adds a small `captureException` helper that emits `$exception` events in the shape error tracking ingests, plus:

- global `error` / `unhandledrejection` handlers registered in all four extension pages (popup, options, configure, applied)
- explicit capture of boundary-caught crashes in `ErrorBoundary`, alongside the existing `ui_crashed` event

Everything goes through the existing `capture()` wrapper, so the analytics opt-out and the never-break-the-extension error swallowing are preserved.

## Test plan

- [x] `pnpm run check` green (format + lint + typecheck)
- [x] All 199 unit tests pass (the partial analytics mocks in the popup and applied entry tests now include the new export)

🤖 Generated with [Claude Code](https://claude.com/claude-code)