### PR TITLE
feat: saving a manual header also enables it (PRO-197)

### DIFF
--- a/changelog.d/+save-enables-header.changed.md
+++ b/changelog.d/+save-enables-header.changed.md
@@ -1,0 +1,1 @@
+Saving a manual header now also enables it, so the header is injected right away without a separate toggle step.

--- a/e2e/extension.spec.ts
+++ b/e2e/extension.spec.ts
@@ -18,10 +18,6 @@ async function addHeader(
     }
     await popupPage.getByRole('button', { name: 'Save' }).click();
     await expect(popupPage.getByText('Saved!')).toBeVisible();
-
-    // Save no longer auto-installs the DNR rule; flip the toggle on
-    // so tests that assert injected headers still pass.
-    await popupPage.getByLabel('Toggle header injection').click();
     await expect(popupPage.getByText('Active', { exact: true })).toBeVisible();
 }
 

--- a/src/__tests__/useHeaderRules.test.ts
+++ b/src/__tests__/useHeaderRules.test.ts
@@ -86,6 +86,9 @@ describe('useHeaderRules analytics', () => {
             (_keys: string[], cb: (result: Record<string, unknown>) => void) =>
                 cb({})
         );
+        mockStorageRemove.mockImplementation(
+            (_keys: string[], cb: () => void) => cb()
+        );
     });
 
     describe('handleToggle', () => {
@@ -231,11 +234,13 @@ describe('useHeaderRules analytics', () => {
             );
         });
 
-        it('does not update DNR rules when no rules are active (toggle off)', async () => {
-            // No active rules, no config — toggle is off
+        it('activates the rule when saving while no rules are active (toggle off)', async () => {
             mockGetDynamicRules.mockImplementation(
                 (cb: (rules: chrome.declarativeNetRequest.Rule[]) => void) =>
                     cb([])
+            );
+            mockUpdateDynamicRules.mockImplementation(
+                (_opts: unknown, cb: () => void) => cb()
             );
             mockStorageSet.mockImplementation(
                 (_data: unknown, cb: () => void) => cb()
@@ -252,7 +257,7 @@ describe('useHeaderRules analytics', () => {
                 await Promise.resolve();
             });
 
-            expect(mockUpdateDynamicRules).not.toHaveBeenCalled();
+            expect(mockUpdateDynamicRules).toHaveBeenCalled();
             expect(mockStorageSet).toHaveBeenCalledTimes(1);
             expect(mockCapture).toHaveBeenCalledWith(
                 'extension_header_rule_saved',
@@ -321,27 +326,6 @@ describe('useHeaderRules analytics', () => {
         });
 
         it('sets error on update_rules failure', async () => {
-            // Must have an active rule for the update path to run on save.
-            const activeRule: chrome.declarativeNetRequest.Rule = {
-                id: 1,
-                priority: 1,
-                action: {
-                    type: 'modifyHeaders' as chrome.declarativeNetRequest.RuleActionType,
-                    requestHeaders: [
-                        {
-                            header: 'X-Test',
-                            operation:
-                                'set' as chrome.declarativeNetRequest.HeaderOperation,
-                            value: 'val',
-                        },
-                    ],
-                },
-                condition: { urlFilter: '|' },
-            };
-            mockGetDynamicRules.mockImplementation(
-                (cb: (rules: chrome.declarativeNetRequest.Rule[]) => void) =>
-                    cb([activeRule])
-            );
             mockUpdateDynamicRules.mockImplementation(
                 (_opts: unknown, cb: () => void) => {
                     (

--- a/src/hooks/useHeaderRules.ts
+++ b/src/hooks/useHeaderRules.ts
@@ -209,43 +209,38 @@ export function useHeaderRules() {
             ...(trimmedScope ? { scope: trimmedScope } : {}),
         };
 
-        // Save is non-destructive: only refresh the active DNR rule
-        // if injection is already turned on. If the toggle is off,
-        // saving persists to storage without activating.
         const wasActive = rules.length > 0;
 
-        if (wasActive) {
-            const newRules = buildDnrRule(
-                headerName.trim(),
-                headerValue.trim(),
-                scope.trim() || undefined
-            );
+        const newRules = buildDnrRule(
+            headerName.trim(),
+            headerValue.trim(),
+            trimmedScope || undefined
+        );
 
-            try {
-                const existingRules = await getDynamicRules();
-                await updateDynamicRules({
-                    removeRuleIds: existingRules.map((r) => r.id),
-                    addRules: newRules,
-                });
-                await storageRemove([
-                    STORAGE_KEYS.JOINED_KEY,
-                    STORAGE_KEYS.JOINED_SESSION_NAME,
-                ]);
-            } catch (e) {
-                const msg =
-                    e instanceof Error ? e.message : STRINGS.ERR_SAVE_FAILED;
-                setError(`${STRINGS.ERR_SAVE_FAILED}: ${msg}`);
-                setSaveState('idle');
-                capture('extension_error', {
-                    action: 'save',
-                    step: 'update_rules',
-                    error: msg,
-                });
-                emitUserBlocked('header_rule_save_failed', 'user_action', {
-                    error: msg,
-                });
-                return;
-            }
+        try {
+            const existingRules = await getDynamicRules();
+            await updateDynamicRules({
+                removeRuleIds: existingRules.map((r) => r.id),
+                addRules: newRules,
+            });
+            await storageRemove([
+                STORAGE_KEYS.JOINED_KEY,
+                STORAGE_KEYS.JOINED_SESSION_NAME,
+            ]);
+        } catch (e) {
+            const msg =
+                e instanceof Error ? e.message : STRINGS.ERR_SAVE_FAILED;
+            setError(`${STRINGS.ERR_SAVE_FAILED}: ${msg}`);
+            setSaveState('idle');
+            capture('extension_error', {
+                action: 'save',
+                step: 'update_rules',
+                error: msg,
+            });
+            emitUserBlocked('header_rule_save_failed', 'user_action', {
+                error: msg,
+            });
+            return;
         }
 
         try {


### PR DESCRIPTION
## Summary

- Saving a manual header now also applies the DNR rule immediately, so the header is active right after Save with no separate toggle step (PRO-197).
- Previously Save only persisted the config while the toggle stayed off, which read as the save not having worked. This intentionally reverses the save-without-activate semantics introduced in #44, per PRO-197.
- The joined-session storage keys are cleared on every save now (matching the activation path), and the saved analytics event keeps its was_active property so the before/after state stays visible.

## Test plan

- [x] pnpm test: 199 unit tests pass, including a rewritten hook test asserting that Save activates the rule when the toggle is off.
- [x] pnpm build and pnpm run check (Prettier, ESLint, tsc) all clean.
- [x] pnpm test:e2e: 10 passed, 3 skipped (live playground specs auto-skip without a token). The shared addHeader helper no longer flips the toggle after Save and instead asserts the Active state, so every e2e spec now verifies headers are injected into real HTTP requests immediately after saving.