### PR TITLE
chore: bump @metalbear/ui to 0.4.0

### DIFF
--- a/changelog.d/+bump-ui-040.internal.md
+++ b/changelog.d/+bump-ui-040.internal.md
@@ -1,0 +1,1 @@
+Bumped `@metalbear/ui` to 0.4.0, which drops the unused white mirrord logo and icon exports.

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
         "vite": "^5.4.19"
     },
     "dependencies": {
-        "@metalbear/ui": "^0.3.1",
+        "@metalbear/ui": "^0.4.0",
         "dayjs": "^1.11.20",
         "lodash.groupby": "^4.6.0",
         "lucide-react": "^0.575.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@metalbear/ui':
-        specifier: ^0.3.1
-        version: 0.3.1(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(eslint@9.28.0(jiti@1.21.7))(prettier@3.5.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.8.3)
+        specifier: ^0.4.0
+        version: 0.4.0(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(eslint@9.28.0(jiti@1.21.7))(prettier@3.5.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.8.3)
       dayjs:
         specifier: ^1.11.20
         version: 1.11.20
@@ -904,8 +904,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@metalbear/ui@0.3.1':
-    resolution: {integrity: sha512-fDb01XJHqRVOUwx4USZ95JwoIRCPwM7NfncAS27GAjfEcF+y6lY8zgWn6WsOzjCQZNXjBIGU6zSX7oypXpxjPQ==}
+  '@metalbear/ui@0.4.0':
+    resolution: {integrity: sha512-hUy5JSgeCRb6dpA1G+kwCTMfVY6E2l6Ft66nEiG56ynQEwDyyj/uEcCXoP8A8cipHBHZ+PnZRtSDk35W1eI2xw==}
     engines: {node: '>=20.11'}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
@@ -5109,7 +5109,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  '@metalbear/ui@0.3.1(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(eslint@9.28.0(jiti@1.21.7))(prettier@3.5.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.8.3)':
+  '@metalbear/ui@0.4.0(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(eslint@9.28.0(jiti@1.21.7))(prettier@3.5.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.8.3)':
     dependencies:
       '@eslint/js': 9.39.5
       '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)


### PR DESCRIPTION
## Summary

Bumps `@metalbear/ui` from 0.3.1 to 0.4.0.

0.4.0 (metalbear-co/ui#33) removes the `MirrordLogoWhite` and `MirrordIconWhite` exports, so the kit ships one standard mirrord logo and one standard mirrord icon used in both light and dark mode. That matches what the popup already does: it renders the standard tiled icon unconditionally in both themes, so there are no code changes here.

Lockfile diff is 6 lines.

## Test plan

- `pnpm install` resolves `@metalbear/ui@0.4.0`.
- `pnpm run check` (prettier, eslint, tsc) passes.
- `pnpm run build` succeeds.
- `pnpm run test` passes, 199 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)