### PR TITLE
fix(analytics): pair popup closed events with opened events per visibility episode

### DIFF
--- a/changelog.d/+popup-closed-episodes.internal.md
+++ b/changelog.d/+popup-closed-episodes.internal.md
@@ -1,0 +1,3 @@
+Popup close telemetry now pairs one closed event with one opened event per
+visibility episode, instead of firing a closed event on every tab switch with
+an ever-growing duration.

--- a/e2e/analytics.spec.ts
+++ b/e2e/analytics.spec.ts
@@ -87,6 +87,13 @@ async function getCapturedEvents(page: Page): Promise<string[]> {
     });
 }
 
+async function getCapturedEventDetails(page: Page): Promise<CapturedEvent[]> {
+    return page.evaluate(() => {
+        const analyticsWindow = window as CapturedAnalyticsWindow;
+        return analyticsWindow.__captured_analytics__ ?? [];
+    });
+}
+
 async function openPopupWithSpy(
     context: BrowserContext,
     extensionId: string
@@ -126,6 +133,44 @@ test.describe('Analytics events', () => {
 
         const events = await getCapturedEvents(page);
         expect(events).toContain('extension_header_rule_saved');
+    });
+
+    test('visibility episodes pair popup closed events with opened events', async ({
+        context,
+        extensionId,
+    }) => {
+        const page = await openPopupWithSpy(context, extensionId);
+        await expect(page.getByText('mirrord', { exact: true })).toBeVisible();
+
+        const setVisibility = (state: 'hidden' | 'visible') =>
+            page.evaluate((visibility) => {
+                Object.defineProperty(document, 'visibilityState', {
+                    configurable: true,
+                    get: () => visibility,
+                });
+                document.dispatchEvent(new Event('visibilitychange'));
+            }, state);
+
+        for (let i = 0; i < 3; i++) {
+            await setVisibility('hidden');
+            await setVisibility('visible');
+        }
+
+        const events = await getCapturedEventDetails(page);
+        const opened = events.filter(
+            (e) => e.event === 'extension_popup_opened'
+        );
+        const closed = events.filter(
+            (e) => e.event === 'extension_popup_closed'
+        );
+        expect(closed).toHaveLength(3);
+        expect(opened).toHaveLength(4);
+        expect(
+            opened.filter((e) => e.properties['resumed'] === true)
+        ).toHaveLength(3);
+        for (const event of closed) {
+            expect(typeof event.properties['duration_ms']).toBe('number');
+        }
     });
 
     test('removing a header rule sends extension_header_rule_removed event', async ({

--- a/src/__tests__/popupLifecycle.test.ts
+++ b/src/__tests__/popupLifecycle.test.ts
@@ -1,0 +1,106 @@
+jest.mock('../analytics', () => ({
+    capture: jest.fn(),
+    captureBeacon: jest.fn(),
+    optOutReady: Promise.resolve(),
+}));
+
+import { capture, captureBeacon } from '../analytics';
+import { trackPopupLifecycle } from '../popupLifecycle';
+
+const captureMock = capture as jest.Mock;
+const beaconMock = captureBeacon as jest.Mock;
+
+function setVisibility(state: DocumentVisibilityState): void {
+    Object.defineProperty(document, 'visibilityState', {
+        configurable: true,
+        get: () => state,
+    });
+    document.dispatchEvent(new Event('visibilitychange'));
+}
+
+describe('trackPopupLifecycle', () => {
+    let cleanup: (() => void) | undefined;
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        cleanup?.();
+        cleanup = undefined;
+        Object.defineProperty(document, 'visibilityState', {
+            configurable: true,
+            get: () => 'visible',
+        });
+        jest.useRealTimers();
+        jest.clearAllMocks();
+    });
+
+    it('reports the initial open once the opt-out state is known', async () => {
+        cleanup = trackPopupLifecycle('side_panel');
+        await Promise.resolve();
+
+        expect(captureMock).toHaveBeenCalledTimes(1);
+        expect(captureMock).toHaveBeenCalledWith('extension_popup_opened', {
+            surface: 'side_panel',
+            resumed: false,
+        });
+        expect(beaconMock).not.toHaveBeenCalled();
+    });
+
+    it('reports closed once when hidden, with the elapsed episode time', () => {
+        cleanup = trackPopupLifecycle('side_panel');
+        jest.advanceTimersByTime(5000);
+
+        setVisibility('hidden');
+        expect(beaconMock).toHaveBeenCalledTimes(1);
+        expect(beaconMock).toHaveBeenCalledWith('extension_popup_closed', {
+            duration_ms: 5000,
+            surface: 'side_panel',
+        });
+
+        document.dispatchEvent(new Event('visibilitychange'));
+        expect(beaconMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('pairs a resumed open with a fresh close on the next episode', async () => {
+        cleanup = trackPopupLifecycle('popup_fallback');
+        await Promise.resolve();
+        jest.advanceTimersByTime(1000);
+        setVisibility('hidden');
+        jest.advanceTimersByTime(60000);
+
+        setVisibility('visible');
+        await Promise.resolve();
+        expect(captureMock).toHaveBeenLastCalledWith('extension_popup_opened', {
+            surface: 'popup_fallback',
+            resumed: true,
+        });
+
+        jest.advanceTimersByTime(2000);
+        setVisibility('hidden');
+        expect(beaconMock).toHaveBeenCalledTimes(2);
+        expect(beaconMock).toHaveBeenLastCalledWith('extension_popup_closed', {
+            duration_ms: 2000,
+            surface: 'popup_fallback',
+        });
+    });
+
+    it('does not report when becoming visible without a prior close', async () => {
+        cleanup = trackPopupLifecycle('side_panel');
+        await Promise.resolve();
+        captureMock.mockClear();
+
+        setVisibility('visible');
+        expect(captureMock).not.toHaveBeenCalled();
+        expect(beaconMock).not.toHaveBeenCalled();
+    });
+
+    it('stops reporting after cleanup', () => {
+        const stop = trackPopupLifecycle('side_panel');
+        stop();
+
+        setVisibility('hidden');
+        expect(beaconMock).not.toHaveBeenCalled();
+    });
+});

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -21,26 +21,15 @@ import type { ThemePref } from './types';
 import { SessionsView, ManualSetup } from './components';
 import { useHeaderRules } from './hooks';
 import { useMirrordUi } from './hooks/useMirrordUi';
-import { capture, captureBeacon, optOutReady } from './analytics';
+import { trackPopupLifecycle, type PopupSurface } from './popupLifecycle';
 import { STRINGS, TAB, type TabId } from './constants';
 import { STORAGE_KEYS } from './types';
 
-const popupOpenedAt = Date.now();
-const surface: 'side_panel' | 'popup_fallback' =
+const surface: PopupSurface =
     typeof (chrome as { sidePanel?: unknown }).sidePanel === 'undefined'
         ? 'popup_fallback'
         : 'side_panel';
-void optOutReady.then(() => capture('extension_popup_opened', { surface }));
-
-document.addEventListener('visibilitychange', () => {
-    if (document.visibilityState !== 'hidden') {
-        return;
-    }
-    captureBeacon('extension_popup_closed', {
-        duration_ms: Date.now() - popupOpenedAt,
-        surface,
-    });
-});
+trackPopupLifecycle(surface);
 
 export function Popup() {
     const headerRules = useHeaderRules();

--- a/src/popupLifecycle.ts
+++ b/src/popupLifecycle.ts
@@ -1,0 +1,34 @@
+import { capture, captureBeacon, optOutReady } from './analytics';
+
+export type PopupSurface = 'side_panel' | 'popup_fallback';
+
+export function trackPopupLifecycle(surface: PopupSurface): () => void {
+    let episodeStart = Date.now();
+    let closeSent = false;
+
+    void optOutReady.then(() =>
+        capture('extension_popup_opened', { surface, resumed: false })
+    );
+
+    const onVisibilityChange = () => {
+        if (document.visibilityState === 'hidden') {
+            if (closeSent) {
+                return;
+            }
+            closeSent = true;
+            captureBeacon('extension_popup_closed', {
+                duration_ms: Date.now() - episodeStart,
+                surface,
+            });
+        } else if (closeSent) {
+            closeSent = false;
+            episodeStart = Date.now();
+            capture('extension_popup_opened', { surface, resumed: true });
+        }
+    };
+
+    document.addEventListener('visibilitychange', onVisibilityChange);
+    return () => {
+        document.removeEventListener('visibilitychange', onVisibilityChange);
+    };
+}


### PR DESCRIPTION
## Summary

The popup fired `extension_popup_closed` on every `visibilitychange` to hidden. The side panel document is not destroyed when the user switches tabs, only hidden, so a single panel session emitted one `extension_popup_opened` and then a closed event for every tab switch, each reporting cumulative wall clock time since the document loaded. Closed events therefore heavily outnumber opened events, and `duration_ms` does not measure engagement.

This change moves the lifecycle telemetry into `trackPopupLifecycle` (new `src/popupLifecycle.ts`), which pairs events per visibility episode:

- becoming hidden sends one closed event with the time elapsed in that episode, and further hidden notifications are ignored until the panel is visible again
- becoming visible after a close sends a new opened event with `resumed: true`, starting a fresh episode

The initial opened event now carries `resumed: false`, so existing analyses can keep counting document loads by filtering on it, while opened and closed counts become one-to-one and `duration_ms` reflects actual visible time per episode.

## Test plan

- `pnpm test`: 204 passed, including 5 new unit tests covering the episode pairing, duration accounting, deduplicated hidden notifications, and listener cleanup
- `pnpm run check` (prettier, eslint, tsc): green
- `pnpm build`: green
- `pnpm exec playwright test analytics.spec.ts`: 4 passed in real Chromium with the built extension loaded, including a new spec asserting three hide/show cycles produce exactly 3 closed and 4 opened events (3 of them `resumed: true`)
- Verified the new e2e spec catches the defect: built `main`'s version of `popup.tsx` and ran the same spec, which fails with 1 opened against 3 closed events, matching the imbalance seen in production telemetry
- Note: the e2e spec drives `visibilitychange` synthetically inside the extension page because Playwright's default launch flags (`--disable-backgrounding-occluded-windows`) suppress real occlusion-driven visibility changes; real tab-switch transitions are exercised by the browser, not this suite