### PR TITLE
fix(popup): validate header name and value before saving a rule

### DIFF
--- a/changelog.d/+header-name-validation.fixed.md
+++ b/changelog.d/+header-name-validation.fixed.md
@@ -1,0 +1,1 @@
+Saving a header rule now validates the header name and value before applying it, showing a clear message instead of a cryptic Chrome rule error when the name contains spaces or ':'.

--- a/src/__tests__/useHeaderRules.test.ts
+++ b/src/__tests__/useHeaderRules.test.ts
@@ -1,5 +1,6 @@
 import { renderHook, act } from '@testing-library/react';
 import type { Config } from '../types';
+import { STRINGS } from '../constants';
 
 // Mock analytics module
 const mockCapture = jest.fn();
@@ -751,6 +752,152 @@ describe('useHeaderRules analytics', () => {
             });
 
             expect(result.current.hasStoredConfig).toBe(true);
+        });
+    });
+
+    describe('header validation', () => {
+        it('rejects a header name containing a colon without touching DNR', async () => {
+            const { result } = renderHook(() => useHeaderRules());
+
+            act(() => {
+                result.current.setHeaderName('X-User: alice');
+                result.current.setHeaderValue('alice');
+            });
+
+            await act(async () => {
+                void result.current.handleSave();
+                await Promise.resolve();
+            });
+
+            expect(result.current.error).toBe(STRINGS.ERR_INVALID_HEADER_NAME);
+            expect(mockUpdateDynamicRules).not.toHaveBeenCalled();
+            expect(mockCapture).toHaveBeenCalledWith('extension_error', {
+                action: 'save',
+                step: 'client_validation',
+                error: 'invalid_header_name',
+            });
+        });
+
+        it('rejects a header name containing spaces', async () => {
+            const { result } = renderHook(() => useHeaderRules());
+
+            act(() => {
+                result.current.setHeaderName('my header');
+                result.current.setHeaderValue('alice');
+            });
+
+            await act(async () => {
+                void result.current.handleSave();
+                await Promise.resolve();
+            });
+
+            expect(result.current.error).toBe(STRINGS.ERR_INVALID_HEADER_NAME);
+            expect(mockUpdateDynamicRules).not.toHaveBeenCalled();
+        });
+
+        it('rejects a header value containing a line break', async () => {
+            const { result } = renderHook(() => useHeaderRules());
+
+            act(() => {
+                result.current.setHeaderName('X-User');
+                result.current.setHeaderValue('line1\nline2');
+            });
+
+            await act(async () => {
+                void result.current.handleSave();
+                await Promise.resolve();
+            });
+
+            expect(result.current.error).toBe(STRINGS.ERR_INVALID_HEADER_VALUE);
+            expect(mockUpdateDynamicRules).not.toHaveBeenCalled();
+        });
+
+        it('saves normally once the name is corrected', async () => {
+            mockUpdateDynamicRules.mockImplementation(
+                (_opts: unknown, cb: () => void) => cb()
+            );
+            mockStorageSet.mockImplementation(
+                (_data: unknown, cb: () => void) => cb()
+            );
+            const { result } = renderHook(() => useHeaderRules());
+
+            act(() => {
+                result.current.setHeaderName('X-User');
+                result.current.setHeaderValue('alice');
+            });
+
+            await act(async () => {
+                void result.current.handleSave();
+                await Promise.resolve();
+            });
+
+            expect(result.current.error).toBeNull();
+            expect(mockUpdateDynamicRules).toHaveBeenCalled();
+        });
+
+        it('blocks toggle-activate when the stored config name is invalid', async () => {
+            mockStorageGet.mockImplementation(
+                (
+                    _keys: string[],
+                    cb: (result: Record<string, unknown>) => void
+                ) =>
+                    cb({
+                        defaults: {
+                            headerName: 'X-User: alice',
+                            headerValue: 'alice',
+                        },
+                    })
+            );
+
+            const { result } = renderHook(() => useHeaderRules());
+
+            await act(async () => {
+                // Wait for initial load
+            });
+
+            await act(async () => {
+                void result.current.handleToggle();
+                await Promise.resolve();
+            });
+
+            expect(result.current.error).toBe(STRINGS.ERR_INVALID_HEADER_NAME);
+            expect(mockUpdateDynamicRules).not.toHaveBeenCalled();
+            expect(mockCapture).toHaveBeenCalledWith('extension_error', {
+                action: 'activate',
+                step: 'client_validation',
+                error: 'invalid_header_name',
+            });
+        });
+
+        it('blocks reset when the stored defaults are invalid', async () => {
+            mockStorageGet.mockImplementation(
+                (
+                    _keys: string[],
+                    cb: (result: Record<string, unknown>) => void
+                ) =>
+                    cb({
+                        defaults: {
+                            headerName: 'bad name',
+                            headerValue: 'alice',
+                        },
+                    })
+            );
+
+            const { result } = renderHook(() => useHeaderRules());
+
+            await act(async () => {
+                // Wait for initial load
+            });
+
+            await act(async () => {
+                void result.current.handleReset();
+                await Promise.resolve();
+            });
+
+            expect(result.current.error).toBe(STRINGS.ERR_INVALID_HEADER_NAME);
+            expect(mockUpdateDynamicRules).not.toHaveBeenCalled();
+            expect(mockStorageRemove).not.toHaveBeenCalled();
+            expect(result.current.resetState).toBe('idle');
         });
     });
 });

--- a/src/__tests__/util.test.ts
+++ b/src/__tests__/util.test.ts
@@ -6,6 +6,8 @@ import {
     buildShareUrl,
     sessionInjectionPair,
     aggregateSessions,
+    isValidHeaderName,
+    isValidHeaderValue,
 } from '../util';
 import type { OperatorSessionSummary } from '../types';
 import { decodeConfig } from '../config';
@@ -365,4 +367,40 @@ describe('aggregateSessions', () => {
         expect(agg.targets.sort()).toEqual(['deployment/web', 'targetless']);
         expect(agg.earliestCreatedAt).toBe('2026-07-13T00:00:00Z');
     });
+});
+
+describe('isValidHeaderName', () => {
+    it.each(['X-MB-Session', 'x_custom.header', 'X-Debug-1', 'authorization'])(
+        'accepts token name %s',
+        (name) => {
+            expect(isValidHeaderName(name)).toBe(true);
+        }
+    );
+
+    it.each([
+        'X-User: alice',
+        'my header',
+        'X-User:',
+        ':authority',
+        'h\u00e9ader',
+        'name\nname',
+    ])('rejects invalid name %s', (name) => {
+        expect(isValidHeaderName(name)).toBe(false);
+    });
+});
+
+describe('isValidHeaderValue', () => {
+    it.each(['alice', 'token=abc; Path=/', 'a b c', 'v\tv', ''])(
+        'accepts value %s',
+        (value) => {
+            expect(isValidHeaderValue(value)).toBe(true);
+        }
+    );
+
+    it.each(['line1\nline2', 'a\rb', 'a\u0000b', 'a\u007fb'])(
+        'rejects control characters in %s',
+        (value) => {
+            expect(isValidHeaderValue(value)).toBe(false);
+        }
+    );
 });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -99,6 +99,10 @@ export const STRINGS = {
     MSG_PATTERN_COUNT: (n: number) => `${n} pattern${n === 1 ? '' : 's'}`,
 
     ERR_HEADER_REQUIRED: 'Header name and value are required',
+    ERR_INVALID_HEADER_NAME:
+        'Header names cannot contain spaces or ":". Enter only the name here and put the value in its own field',
+    ERR_INVALID_HEADER_VALUE:
+        'Header values cannot contain line breaks or other control characters',
     ERR_REMOVE_RULE: 'Failed to remove rule',
     ERR_SAVE_FAILED: 'Failed to save',
     ERR_NO_DEFAULTS: 'No defaults available',

--- a/src/hooks/useHeaderRules.ts
+++ b/src/hooks/useHeaderRules.ts
@@ -9,6 +9,8 @@ import {
     storageSet,
     storageRemove,
     buildShareUrl,
+    isValidHeaderName,
+    isValidHeaderValue,
 } from '../util';
 import type { Config, StoredConfig } from '../types';
 import { STORAGE_KEYS } from '../types';
@@ -38,6 +40,31 @@ export function useHeaderRules() {
     const [shareState, setShareState] = useState<ShareState>('idle');
 
     const canShare = !!headerName.trim() && !!headerValue.trim();
+
+    const validateHeader = useCallback(
+        (name: string, value: string, action: string): boolean => {
+            if (!isValidHeaderName(name)) {
+                setError(STRINGS.ERR_INVALID_HEADER_NAME);
+                capture('extension_error', {
+                    action,
+                    step: 'client_validation',
+                    error: 'invalid_header_name',
+                });
+                return false;
+            }
+            if (!isValidHeaderValue(value)) {
+                setError(STRINGS.ERR_INVALID_HEADER_VALUE);
+                capture('extension_error', {
+                    action,
+                    step: 'client_validation',
+                    error: 'invalid_header_value',
+                });
+                return false;
+            }
+            return true;
+        },
+        []
+    );
 
     const loadRules = useCallback(async () => {
         const chromeRules = await getDynamicRules();
@@ -104,6 +131,12 @@ export function useHeaderRules() {
             return;
         }
 
+        if (
+            !validateHeader(config.headerName, config.headerValue, 'activate')
+        ) {
+            return;
+        }
+
         const newRules = buildDnrRule(
             config.headerName,
             config.headerValue,
@@ -137,9 +170,10 @@ export function useHeaderRules() {
             });
             emitUserBlocked('header_rule_save_failed', 'user_action', {
                 error: msg,
+                action: 'activate',
             });
         }
-    }, [loadRules]);
+    }, [loadRules, validateHeader]);
 
     const handleRemoveAll = useCallback(async () => {
         setError(null);
@@ -195,8 +229,15 @@ export function useHeaderRules() {
     const handleSave = useCallback(async () => {
         setError(null);
 
-        if (!headerName.trim() || !headerValue.trim()) {
+        const trimmedName = headerName.trim();
+        const trimmedValue = headerValue.trim();
+
+        if (!trimmedName || !trimmedValue) {
             setError(STRINGS.ERR_HEADER_REQUIRED);
+            return;
+        }
+
+        if (!validateHeader(trimmedName, trimmedValue, 'save')) {
             return;
         }
 
@@ -204,16 +245,16 @@ export function useHeaderRules() {
 
         const trimmedScope = scope.trim();
         const override: StoredConfig = {
-            headerName: headerName.trim(),
-            headerValue: headerValue.trim(),
+            headerName: trimmedName,
+            headerValue: trimmedValue,
             ...(trimmedScope ? { scope: trimmedScope } : {}),
         };
 
         const wasActive = rules.length > 0;
 
         const newRules = buildDnrRule(
-            headerName.trim(),
-            headerValue.trim(),
+            trimmedName,
+            trimmedValue,
             trimmedScope || undefined
         );
 
@@ -239,6 +280,8 @@ export function useHeaderRules() {
             });
             emitUserBlocked('header_rule_save_failed', 'user_action', {
                 error: msg,
+                action: 'save',
+                step: 'update_rules',
             });
             return;
         }
@@ -257,6 +300,8 @@ export function useHeaderRules() {
             });
             emitUserBlocked('header_rule_save_failed', 'user_action', {
                 error: msg,
+                action: 'save',
+                step: 'storage_write',
             });
             return;
         }
@@ -269,9 +314,9 @@ export function useHeaderRules() {
             has_scope: !!scope.trim(),
             was_active: wasActive,
         });
-        armCanary({ headerName: headerName.trim(), flow: 'header_injector' });
+        armCanary({ headerName: trimmedName, flow: 'header_injector' });
         emitUserSucceeded('header_rule_saved', 'user_action');
-    }, [headerName, headerValue, scope, loadRules, rules]);
+    }, [headerName, headerValue, scope, loadRules, rules, validateHeader]);
 
     const handleReset = useCallback(async () => {
         setError(null);
@@ -284,6 +329,13 @@ export function useHeaderRules() {
 
         if (!defaults) {
             setError(STRINGS.ERR_NO_DEFAULTS);
+            setResetState('idle');
+            return;
+        }
+
+        if (
+            !validateHeader(defaults.headerName, defaults.headerValue, 'reset')
+        ) {
             setResetState('idle');
             return;
         }
@@ -343,7 +395,7 @@ export function useHeaderRules() {
         capture('extension_header_rule_reset');
         cancelCanary();
         emitUserSucceeded('header_rule_reset', 'user_action');
-    }, [loadRules]);
+    }, [loadRules, validateHeader]);
 
     const handleShare = useCallback(async () => {
         if (!canShare) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -70,6 +70,26 @@ export function parseRules(
     }));
 }
 
+const HEADER_NAME_RE = /^[!#$%&'*+\-.^_`|~A-Za-z0-9]+$/;
+
+export function isValidHeaderName(name: string): boolean {
+    return HEADER_NAME_RE.test(name);
+}
+
+const CHAR_TAB = 0x09;
+const CHAR_SPACE = 0x20;
+const CHAR_DELETE = 0x7f;
+
+export function isValidHeaderValue(value: string): boolean {
+    for (const ch of value) {
+        const code = ch.codePointAt(0) ?? 0;
+        if ((code < CHAR_SPACE && code !== CHAR_TAB) || code === CHAR_DELETE) {
+            return false;
+        }
+    }
+    return true;
+}
+
 export function buildDnrRule(
     header: string,
     value: string,


### PR DESCRIPTION
## Summary

A recurring blocked-save signature on the browser extension shows users hitting Chrome's raw declarativeNetRequest error ("Rule with id 1 must specify a valid header name to be modified.") when saving a header rule. The popup only checked that the name and value were non-empty, so a name that is not a valid HTTP token (a pasted "Name: value" combo, a name with spaces) went straight to Chrome and failed with that cryptic, non-actionable message.

- Add `isValidHeaderName` (RFC 7230 token) and `isValidHeaderValue` (no control characters) to `util.ts`.
- Validate in all three DNR write paths in `useHeaderRules` (save, toggle-activate on stored config, reset to defaults) before touching `updateDynamicRules`, and show a clear message that tells the user what to fix.
- Client-side validation failures emit an `extension_error` analytics event (`step: client_validation`) instead of a user-blocked alert; real DNR failures now also carry `action`/`step` so they can be attributed to the path that failed.

## Test plan

- `pnpm test`: 224/224 pass, including new unit tests for both validators and 6 new hook tests (invalid name/value rejected without calling `updateDynamicRules` on save/toggle/reset, valid save unaffected).
- `pnpm run check` (prettier + eslint) and `pnpm build`: green.
- Ran the built extension in headed Chromium via a temporary Playwright spec using the repo's e2e fixtures (spec verified locally, then removed): saving name "X-User: alice" shows the new message and writes no DNR rule; calling `updateDynamicRules` directly with that name reproduces Chrome's exact "must specify a valid header name" error; a valid save still ends with Saved!/Active.
- Existing e2e suites (`extension.spec.ts`, `analytics.spec.ts`): 10/10 pass against the built extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)