### PR TITLE
fix(popup): stop stacking session polls and bound how long one runs

### DIFF
--- a/changelog.d/+bound-session-poll.fixed.md
+++ b/changelog.d/+bound-session-poll.fixed.md
@@ -1,0 +1,1 @@
+The popup no longer stacks session-list requests when `mirrord ui` is slow to answer, and gives up on one after 15 seconds instead of waiting indefinitely.

--- a/src/__tests__/useMirrordUi.test.ts
+++ b/src/__tests__/useMirrordUi.test.ts
@@ -185,6 +185,48 @@ test('fetches sessions on mount when backend is configured', async () => {
     expect(Object.keys(result.current.groupedFiltered)).toContain('k1');
 });
 
+test('does not start another session poll while one is still in flight', async () => {
+    jest.useFakeTimers();
+    let sessionCalls = 0;
+    global.fetch = jest.fn((url: RequestInfo | URL) => {
+        const u = urlToString(url);
+        if (u.includes('/health')) {
+            return Promise.resolve({
+                ok: true,
+                status: 200,
+                statusText: 'OK',
+                text: () => Promise.resolve('ok'),
+                json: () => Promise.resolve({}),
+            } as unknown as Response);
+        }
+        if (u.includes('/api/operator-sessions')) {
+            sessionCalls += 1;
+            return new Promise<Response>(() => {
+                // Never settles, so the poll stays in flight across the next ticks.
+            });
+        }
+        return Promise.reject(new Error('unexpected fetch'));
+    });
+
+    const { unmount } = renderHook(() => useMirrordUi());
+    await act(async () => {
+        await Promise.resolve();
+    });
+    await act(async () => {
+        await Promise.resolve();
+    });
+    expect(sessionCalls).toBe(1);
+
+    await act(async () => {
+        jest.advanceTimersByTime(20_000);
+        await Promise.resolve();
+    });
+    expect(sessionCalls).toBe(1);
+
+    unmount();
+    jest.useRealTimers();
+});
+
 test('flags authFailed when the poller rejects the token (401)', async () => {
     global.fetch = jest.fn((url: RequestInfo | URL) => {
         const u = urlToString(url);

--- a/src/hooks/useMirrordUi.ts
+++ b/src/hooks/useMirrordUi.ts
@@ -34,18 +34,37 @@ const HTTP_NOT_FOUND = 404;
 const HTTP_UNAUTHORIZED = 401;
 const HTTP_FORBIDDEN = 403;
 
+// Listing sessions round-trips through the operator to the Kubernetes API, so it can outlast the
+// poll interval on a slow or unreachable cluster. Bounding it keeps a stalled request from holding
+// one of the origin's few connections until the browser gives up on it.
+const MS_PER_SEC = 1000;
+const REQUEST_TIMEOUT_SEC = 15;
+const REQUEST_TIMEOUT_MS = REQUEST_TIMEOUT_SEC * MS_PER_SEC;
+
+/**
+ * True for the rejection `AbortSignal.timeout` produces. A request we gave up on says the server
+ * was too slow, which is a different fault from one the browser could not send at all — and the
+ * message it carries ("signal timed out", "The operation timed out", ...) is vendor-specific.
+ */
+export function isTimeout(err: unknown): boolean {
+    return err instanceof DOMException && err.name === 'TimeoutError';
+}
+
 export async function fetchOperatorSessions(
     backend: string,
     token: string,
-    fetchImpl: typeof fetch = fetch
+    fetchImpl: typeof fetch = fetch,
+    signal: AbortSignal = AbortSignal.timeout(REQUEST_TIMEOUT_MS)
 ): Promise<OperatorSessionsResponse> {
     const url = `${backend}/api/operator-sessions`;
     const resp = await fetchImpl(url, {
         headers: { 'x-auth-token': token },
+        signal,
     });
     if (isAuthFailureStatus(resp.status)) {
         const retry = await fetchImpl(
-            `${url}?token=${encodeURIComponent(token)}`
+            `${url}?token=${encodeURIComponent(token)}`,
+            { signal }
         );
         if (retry.ok) {
             try {
@@ -117,7 +136,8 @@ export async function fetchOperatorSessionsV2(
     backend: string,
     token: string,
     context: string | null,
-    fetchImpl: typeof fetch = fetch
+    fetchImpl: typeof fetch = fetch,
+    signal: AbortSignal = AbortSignal.timeout(REQUEST_TIMEOUT_MS)
 ): Promise<OperatorSessionsResponse> {
     const params = new URLSearchParams();
     if (context) {
@@ -126,6 +146,7 @@ export async function fetchOperatorSessionsV2(
     const url = `${backend}/api/v2/operator/sessions?${params.toString()}`;
     const resp = await fetchImpl(url, {
         headers: { 'x-auth-token': token },
+        signal,
     });
     if (!resp.ok) {
         const e = new Error(
@@ -157,7 +178,11 @@ async function runPoll(
         }
         return { ok: true, data: resp };
     } catch (err) {
-        const error = err instanceof Error ? err.message : String(err);
+        const error = isTimeout(err)
+            ? `timed out after ${REQUEST_TIMEOUT_SEC}s`
+            : err instanceof Error
+              ? err.message
+              : String(err);
         const status =
             err instanceof Error &&
             typeof (err as Error & { status?: unknown }).status === 'number'
@@ -277,6 +302,10 @@ export function useMirrordUi() {
     const joinedValueRef = useRef<string | null>(null);
 
     const wsRef = useRef<WebSocket | null>(null);
+    // A poll still in flight when the next tick arrives. Ticking regardless would stack one
+    // round-trip per interval against a server that is already too slow to keep up, and the browser
+    // allows only a handful of concurrent connections per origin.
+    const pollInFlight = useRef(false);
 
     // The context whose sessions we show: the user's pick, else the kubeconfig's current context.
     const effectiveContext = selectedContext ?? currentContext;
@@ -435,8 +464,12 @@ export function useMirrordUi() {
         }
         let cancelled = false;
         const refresh = () => {
-            void runPoll(backend, token, v2Available, effectiveContext).then(
-                (result) => {
+            if (pollInFlight.current) {
+                return;
+            }
+            pollInFlight.current = true;
+            void runPoll(backend, token, v2Available, effectiveContext)
+                .then((result) => {
                     if (cancelled) {
                         return;
                     }
@@ -448,8 +481,10 @@ export function useMirrordUi() {
                     } else {
                         setAuthFailed(isAuthFailureStatus(result.status));
                     }
-                }
-            );
+                })
+                .finally(() => {
+                    pollInFlight.current = false;
+                });
         };
         refresh();
         const interval = setInterval(refresh, OPERATOR_SESSIONS_POLL_MS);


### PR DESCRIPTION
## Summary

The popup polls the `mirrord ui` session list every 5s with no in-flight guard and no timeout. Listing sessions round-trips through the operator to the Kubernetes API, so on a slow or unreachable cluster a single request can far outlast the poll interval, and every tick opened another one.

Once six are outstanding the browser's per-origin connection limit is saturated, and the popup stops issuing requests entirely. It also reports nothing while this happens: the recurring `bridge_unhealthy` signature with a bare `Failed to fetch` and no status is the browser eventually giving up on one of the stacked requests, minutes after the bridge actually stopped working.

- Skip a tick when a poll is still in flight.
- Bound every session request at 15s (defaulted on the fetch helpers, so the one-shot callers in `background.ts`, `configure.tsx`, and `joinSession.ts` are bounded too).
- Report a request we gave up on as a timeout instead of as an unreachable server, so a slow cluster stops looking identical to a dead `mirrord ui`.

Same defect and same shape as metalbear-co/mirrord#4697, one surface over.

## Test plan

`pnpm run check` (prettier, eslint, tsc) and `pnpm test` (200 unit tests) both pass.

Added a unit test asserting a second poll does not start while one is in flight. Verified it actually catches the regression: with the guard disabled it fails with `Expected: 1, Received: 5`.

End-to-end against the built bundle. Stub `mirrord ui` on loopback: `/health` and `/api/v2/kube/contexts` answer normally, `/api/v2/operator/sessions` accepts the connection and never answers. The extension is loaded unpacked into Chromium via Playwright, the popup page is held open for 60s, the stub counts concurrent in-flight requests, and telemetry is read off the wire by intercepting the analytics host.

| | `main` | this branch |
|---|---|---|
| session requests opened | 6 | 4 |
| max concurrent | 6 | 1 |
| released before the window ended | 0 | 3 |
| last request opened at | 30.6s, then nothing for 30s | steady, one at a time |
| health events emitted | none | `bridge_unhealthy`, `error: "timed out after 15s"` |

`main` going quiet after the sixth request is the per-origin connection cap being saturated, and it emitted no telemetry at all across the full window.

Control validity: the control was built by checking out `main`'s copy of the changed file after committing; restoring it rebuilt to the same content-hashed bundle filename as the originally verified branch build.

Not exercised: no run against a real `mirrord ui` talking to a real cluster.