### PR TITLE
[bot] feat: user-defined URL redirect rules

### DIFF
--- a/changelog.d/+url-redirect-rules.added.md
+++ b/changelog.d/+url-redirect-rules.added.md
@@ -1,0 +1,1 @@
+Added URL redirect rules: rewrite matching request URLs (RE2 pattern → substitution) before they are sent, e.g. to map per-env hostnames the app builds from the injected header back onto a host that exists. Managed from a new "URL redirects" section in the popup; header save/join/leave flows no longer touch redirect rules.

--- a/src/__tests__/redirects.test.ts
+++ b/src/__tests__/redirects.test.ts
@@ -1,0 +1,190 @@
+import {
+    buildRedirectDnrRules,
+    headerRuleIds,
+    isRedirectDnrRule,
+} from '../util';
+import {
+    addRedirectRule,
+    getRedirectRules,
+    removeRedirectRule,
+    setRedirectRules,
+} from '../redirects';
+import {
+    ALL_RESOURCE_TYPES,
+    REDIRECT_RULE_ID_BASE,
+    STORAGE_KEYS,
+} from '../types';
+
+function mockChrome(overrides: {
+    dynamicRules?: chrome.declarativeNetRequest.Rule[];
+    storage?: Record<string, unknown>;
+}) {
+    const storage = overrides.storage ?? {};
+    const updateDynamicRules = jest.fn(
+        (
+            _opts: chrome.declarativeNetRequest.UpdateRuleOptions,
+            cb: () => void
+        ) => cb()
+    );
+    globalThis.chrome = {
+        runtime: {},
+        declarativeNetRequest: {
+            RuleActionType: {
+                MODIFY_HEADERS: 'modifyHeaders',
+                REDIRECT: 'redirect',
+            },
+            getDynamicRules: jest.fn(
+                (cb: (rules: chrome.declarativeNetRequest.Rule[]) => void) =>
+                    cb(overrides.dynamicRules ?? [])
+            ),
+            updateDynamicRules,
+        },
+        storage: {
+            local: {
+                get: jest.fn(
+                    (
+                        _keys: string[],
+                        cb: (result: Record<string, unknown>) => void
+                    ) => cb(storage)
+                ),
+                set: jest.fn(
+                    (data: Record<string, unknown>, cb: () => void) => {
+                        Object.assign(storage, data);
+                        cb();
+                    }
+                ),
+            },
+        },
+    } as unknown as typeof chrome;
+    return { updateDynamicRules, storage };
+}
+
+const HEADER_RULE = {
+    id: 1,
+    priority: 1,
+    action: {
+        type: 'modifyHeaders' as chrome.declarativeNetRequest.RuleActionType,
+        requestHeaders: [
+            {
+                header: 'X-Test',
+                operation:
+                    'set' as chrome.declarativeNetRequest.HeaderOperation,
+                value: 'v',
+            },
+        ],
+    },
+    condition: { urlFilter: '|' },
+};
+
+const REDIRECT_DNR_RULE = {
+    id: REDIRECT_RULE_ID_BASE,
+    priority: 1,
+    action: {
+        type: 'redirect' as chrome.declarativeNetRequest.RuleActionType,
+        redirect: { regexSubstitution: 'https://app-master.example.com/\\1' },
+    },
+    condition: { regexFilter: '^https://app-[^.]*\\.example\\.com/(.*)' },
+};
+
+describe('buildRedirectDnrRules', () => {
+    beforeEach(() => {
+        mockChrome({});
+    });
+
+    it('builds redirect rules in the reserved id range', () => {
+        const rules = buildRedirectDnrRules([
+            {
+                from: '^https://app-[^.]*\\.example\\.com/(.*)',
+                to: 'https://app-master.example.com/\\1',
+            },
+            {
+                from: '^https://other\\.example\\.com/',
+                to: 'https://x.example.com/',
+            },
+        ]);
+
+        expect(rules).toHaveLength(2);
+        expect(rules[0]?.id).toBe(REDIRECT_RULE_ID_BASE);
+        expect(rules[1]?.id).toBe(REDIRECT_RULE_ID_BASE + 1);
+        expect(rules[0]?.action.type).toBe('redirect');
+        expect(rules[0]?.action.redirect?.regexSubstitution).toBe(
+            'https://app-master.example.com/\\1'
+        );
+        expect(rules[0]?.condition.regexFilter).toBe(
+            '^https://app-[^.]*\\.example\\.com/(.*)'
+        );
+        expect(rules[0]?.condition.resourceTypes).toEqual(ALL_RESOURCE_TYPES);
+    });
+});
+
+describe('headerRuleIds / isRedirectDnrRule', () => {
+    it('excludes redirect-range rules from header wipe ids', () => {
+        expect(isRedirectDnrRule(HEADER_RULE)).toBe(false);
+        expect(isRedirectDnrRule(REDIRECT_DNR_RULE)).toBe(true);
+        expect(headerRuleIds([HEADER_RULE, REDIRECT_DNR_RULE])).toEqual([1]);
+    });
+});
+
+describe('redirect rule storage sync', () => {
+    it('setRedirectRules removes only redirect-range rules and stores the list', async () => {
+        const { updateDynamicRules, storage } = mockChrome({
+            dynamicRules: [HEADER_RULE, REDIRECT_DNR_RULE],
+        });
+
+        const next = [
+            {
+                from: '^https://a\\.example\\.com/',
+                to: 'https://b.example.com/',
+            },
+        ];
+        await setRedirectRules(next);
+
+        const opts = updateDynamicRules.mock.calls[0]?.[0];
+        expect(opts?.removeRuleIds).toEqual([REDIRECT_RULE_ID_BASE]);
+        expect(opts?.addRules?.map((r) => r.id)).toEqual([
+            REDIRECT_RULE_ID_BASE,
+        ]);
+        expect(storage[STORAGE_KEYS.REDIRECT_RULES]).toEqual(next);
+    });
+
+    it('addRedirectRule appends to the stored list', async () => {
+        const existing = [
+            {
+                from: '^https://a\\.example\\.com/',
+                to: 'https://b.example.com/',
+            },
+        ];
+        const { storage } = mockChrome({
+            storage: { [STORAGE_KEYS.REDIRECT_RULES]: [...existing] },
+        });
+
+        await addRedirectRule({
+            from: '^https://c\\.example\\.com/',
+            to: 'https://d.example.com/',
+        });
+
+        expect(storage[STORAGE_KEYS.REDIRECT_RULES]).toHaveLength(2);
+    });
+
+    it('removeRedirectRule drops by index', async () => {
+        const { storage } = mockChrome({
+            storage: {
+                [STORAGE_KEYS.REDIRECT_RULES]: [
+                    { from: 'a', to: 'b' },
+                    { from: 'c', to: 'd' },
+                ],
+            },
+        });
+
+        await removeRedirectRule(0);
+
+        expect(storage[STORAGE_KEYS.REDIRECT_RULES]).toEqual([
+            { from: 'c', to: 'd' },
+        ]);
+    });
+
+    it('getRedirectRules returns empty list when nothing stored', async () => {
+        mockChrome({});
+        expect(await getRedirectRules()).toEqual([]);
+    });
+});

--- a/src/applyConfig.ts
+++ b/src/applyConfig.ts
@@ -6,6 +6,7 @@
 import {
     buildDnrRule,
     getDynamicRules,
+    headerRuleIds,
     refreshIconIndicator,
     storageRemove,
     storageSet,
@@ -21,10 +22,7 @@ export async function applyHeaderConfig(
     const existing = await getDynamicRules();
     const rules = buildDnrRule(header, value, scope);
     await updateDynamicRules({
-        removeRuleIds: [
-            ...rules.map((r) => r.id),
-            ...existing.map((r) => r.id),
-        ],
+        removeRuleIds: [...rules.map((r) => r.id), ...headerRuleIds(existing)],
         addRules: rules,
     });
     // Replace any joined-session state and store under OVERRIDE so the user's saved defaults

--- a/src/background.ts
+++ b/src/background.ts
@@ -3,6 +3,7 @@ import type { OperatorSessionSummary } from './types';
 import {
     buildDnrRule,
     getDynamicRules,
+    headerRuleIds,
     refreshIconIndicator,
     sessionInjectionPair,
     storageGet,
@@ -287,7 +288,7 @@ export async function handleJoin(key: string) {
             (stored[STORAGE_KEYS.SCOPE_PATTERNS] as string[] | undefined) ?? [];
         const existing = await getDynamicRules();
         await updateDynamicRules({
-            removeRuleIds: existing.map((r) => r.id),
+            removeRuleIds: headerRuleIds(existing),
             addRules: buildDnrRule(header, value, scope),
         });
         await storageSet({
@@ -317,7 +318,7 @@ export async function handleLeave() {
     try {
         const existing = await getDynamicRules();
         await updateDynamicRules({
-            removeRuleIds: existing.map((r) => r.id),
+            removeRuleIds: headerRuleIds(existing),
             addRules: [],
         });
         await storageRemove([

--- a/src/components/RedirectsSection.tsx
+++ b/src/components/RedirectsSection.tsx
@@ -1,0 +1,103 @@
+import { Button, Card, CardContent, Input } from '@metalbear/ui';
+import { ArrowRight, X } from 'lucide-react';
+import { STRINGS } from '../constants';
+import type { useRedirectRules } from '../hooks/useRedirectRules';
+
+interface Props {
+    redirectRules: ReturnType<typeof useRedirectRules>;
+}
+
+// Compact list + add form for URL redirect rules. Shown on both tabs since
+// redirects apply regardless of whether the header came from a joined session
+// or a manual override.
+export function RedirectsSection({ redirectRules }: Props) {
+    const {
+        redirects,
+        from,
+        to,
+        error,
+        setFrom,
+        setTo,
+        handleAdd,
+        handleRemove,
+    } = redirectRules;
+
+    return (
+        <Card className="overflow-hidden">
+            <CardContent className="flex flex-col gap-2 px-3 py-2">
+                <div className="flex items-center justify-between">
+                    <span className="text-xs font-medium">
+                        {STRINGS.LABEL_REDIRECTS_HEADING}
+                    </span>
+                    <span className="text-meta text-muted-foreground">
+                        {STRINGS.MSG_REDIRECT_COUNT(redirects.length)}
+                    </span>
+                </div>
+                {redirects.map((rule, idx) => (
+                    <div
+                        key={`${rule.from}\n${rule.to}`}
+                        className="flex items-center gap-1.5"
+                    >
+                        <code
+                            className="min-w-0 flex-1 truncate font-mono text-xs"
+                            title={rule.from}
+                        >
+                            {rule.from}
+                        </code>
+                        <ArrowRight
+                            size={12}
+                            className="text-muted-foreground shrink-0"
+                        />
+                        <code
+                            className="min-w-0 flex-1 truncate font-mono text-xs"
+                            title={rule.to}
+                        >
+                            {rule.to}
+                        </code>
+                        <Button
+                            size="icon"
+                            variant="ghost"
+                            className="h-6 w-6 shrink-0"
+                            onClick={() => void handleRemove(idx)}
+                            aria-label={STRINGS.LABEL_REMOVE_REDIRECT}
+                            title={STRINGS.LABEL_REMOVE_REDIRECT}
+                        >
+                            <X size={12} />
+                        </Button>
+                    </div>
+                ))}
+                <div className="flex items-center gap-1.5">
+                    <Input
+                        value={from}
+                        onChange={(e) => setFrom(e.target.value)}
+                        placeholder={STRINGS.PLACEHOLDER_REDIRECT_FROM}
+                        aria-label={STRINGS.LABEL_REDIRECT_FROM}
+                        className="h-7 flex-1 font-mono text-xs"
+                    />
+                    <Input
+                        value={to}
+                        onChange={(e) => setTo(e.target.value)}
+                        placeholder={STRINGS.PLACEHOLDER_REDIRECT_TO}
+                        aria-label={STRINGS.LABEL_REDIRECT_TO}
+                        className="h-7 flex-1 font-mono text-xs"
+                    />
+                    <Button
+                        variant="outline"
+                        className="h-7 px-2 text-xs"
+                        onClick={() => void handleAdd()}
+                    >
+                        {STRINGS.BTN_ADD_REDIRECT}
+                    </Button>
+                </div>
+                <p className="text-meta text-muted-foreground">
+                    {STRINGS.MSG_REDIRECT_HINT}
+                </p>
+                {error && (
+                    <p className="text-meta text-destructive" role="alert">
+                        {error}
+                    </p>
+                )}
+            </CardContent>
+        </Card>
+    );
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -9,3 +9,4 @@ export { ManualSetup } from './ManualSetup';
 export { StatusDot } from './StatusDot';
 export { NotConfiguredPrompt } from './NotConfiguredPrompt';
 export { OperatorUnavailableNote } from './OperatorUnavailableNote';
+export { RedirectsSection } from './RedirectsSection';

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
 import '@metalbear/ui/styles.css';
-import { refreshIconIndicator } from './util';
+import { headerRuleIds, refreshIconIndicator } from './util';
 import type { Config, StoredConfig } from './types';
 import { STORAGE_KEYS, ALL_RESOURCE_TYPES } from './types';
 import { capture, emitUserBlocked, emitUserSucceeded } from './analytics';
@@ -142,7 +142,7 @@ function setHeaderRule(
                 {
                     removeRuleIds: rules
                         .map(({ id }) => id)
-                        .concat(existingRules.map((rule) => rule.id)),
+                        .concat(headerRuleIds(existingRules)),
                     addRules: rules,
                 },
                 () => {

--- a/src/configure.tsx
+++ b/src/configure.tsx
@@ -13,6 +13,7 @@ import { fetchOperatorSessions } from './hooks/useMirrordUi';
 import {
     buildDnrRule,
     getDynamicRules,
+    headerRuleIds,
     updateDynamicRules,
     storageGet,
     storageSet,
@@ -57,7 +58,7 @@ async function joinKey(
     const value = `mirrord-session=${key}`;
     const existing = await getDynamicRules();
     await updateDynamicRules({
-        removeRuleIds: existing.map((r) => r.id),
+        removeRuleIds: headerRuleIds(existing),
         addRules: buildDnrRule(header, value),
     });
     await storageSet({

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -98,6 +98,19 @@ export const STRINGS = {
     MSG_NO_SESSIONS_MATCH_QUERY: 'No sessions match your search.',
     MSG_PATTERN_COUNT: (n: number) => `${n} pattern${n === 1 ? '' : 's'}`,
 
+    LABEL_REDIRECTS_HEADING: 'URL redirects',
+    LABEL_REDIRECT_FROM: 'Redirect from pattern',
+    LABEL_REDIRECT_TO: 'Redirect to substitution',
+    LABEL_REMOVE_REDIRECT: 'Remove redirect',
+    PLACEHOLDER_REDIRECT_FROM: '^https://app-[^.]*\\.example\\.com/(.*)',
+    PLACEHOLDER_REDIRECT_TO: 'https://app-master.example.com/\\1',
+    BTN_ADD_REDIRECT: 'Add',
+    MSG_REDIRECT_COUNT: (n: number) => `${n} redirect${n === 1 ? '' : 's'}`,
+    MSG_REDIRECT_HINT:
+        'Rewrite matching URLs before the request is sent (RE2 pattern → substitution, \\1..\\9 for capture groups). Useful when the app links to per-env hosts that don’t exist while you work through mirrord.',
+    ERR_REDIRECT_REQUIRED: 'Both pattern and substitution are required',
+    ERR_REDIRECT_INVALID: 'Invalid redirect rule',
+
     ERR_HEADER_REQUIRED: 'Header name and value are required',
     ERR_REMOVE_RULE: 'Failed to remove rule',
     ERR_SAVE_FAILED: 'Failed to save',

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,2 +1,3 @@
 export { useHeaderRules } from './useHeaderRules';
 export { useJoinLiveness, type JoinLiveness } from './useJoinLiveness';
+export { useRedirectRules } from './useRedirectRules';

--- a/src/hooks/useHeaderRules.ts
+++ b/src/hooks/useHeaderRules.ts
@@ -4,6 +4,7 @@ import {
     parseRules,
     buildDnrRule,
     getDynamicRules,
+    headerRuleIds,
     updateDynamicRules,
     storageGet,
     storageSet,
@@ -113,7 +114,7 @@ export function useHeaderRules() {
         try {
             const existingRules = await getDynamicRules();
             await updateDynamicRules({
-                removeRuleIds: existingRules.map((r) => r.id),
+                removeRuleIds: headerRuleIds(existingRules),
                 addRules: newRules,
             });
             await storageRemove([
@@ -146,7 +147,7 @@ export function useHeaderRules() {
         try {
             const existingRules = await getDynamicRules();
             await updateDynamicRules({
-                removeRuleIds: existingRules.map((r) => r.id),
+                removeRuleIds: headerRuleIds(existingRules),
                 addRules: [],
             });
             await storageRemove([
@@ -220,7 +221,7 @@ export function useHeaderRules() {
         try {
             const existingRules = await getDynamicRules();
             await updateDynamicRules({
-                removeRuleIds: existingRules.map((r) => r.id),
+                removeRuleIds: headerRuleIds(existingRules),
                 addRules: newRules,
             });
             await storageRemove([
@@ -315,7 +316,7 @@ export function useHeaderRules() {
         try {
             const existingRules = await getDynamicRules();
             await updateDynamicRules({
-                removeRuleIds: existingRules.map((r) => r.id),
+                removeRuleIds: headerRuleIds(existingRules),
                 addRules: newRules,
             });
         } catch (e) {

--- a/src/hooks/useMirrordUi.ts
+++ b/src/hooks/useMirrordUi.ts
@@ -21,6 +21,7 @@ import {
     storageSet,
     storageRemove,
     getDynamicRules,
+    headerRuleIds,
     updateDynamicRules,
     sessionInjectionPair,
     buildDnrRule,
@@ -529,7 +530,7 @@ export function useMirrordUi() {
             const { header, value } = sessionInjectionPair(target);
             const existing = await getDynamicRules();
             await updateDynamicRules({
-                removeRuleIds: existing.map((r) => r.id),
+                removeRuleIds: headerRuleIds(existing),
                 addRules: buildDnrRule(header, value, scopePatterns),
             });
             await storageSet({
@@ -553,7 +554,7 @@ export function useMirrordUi() {
     const clearJoin = useCallback(async () => {
         const existing = await getDynamicRules();
         await updateDynamicRules({
-            removeRuleIds: existing.map((r) => r.id),
+            removeRuleIds: headerRuleIds(existing),
             addRules: [],
         });
         await storageRemove([
@@ -584,7 +585,7 @@ export function useMirrordUi() {
         if (header && value) {
             const existing = await getDynamicRules();
             await updateDynamicRules({
-                removeRuleIds: existing.map((r) => r.id),
+                removeRuleIds: headerRuleIds(existing),
                 addRules: buildDnrRule(header, value, dedup),
             });
         }

--- a/src/hooks/useRedirectRules.ts
+++ b/src/hooks/useRedirectRules.ts
@@ -1,0 +1,95 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+    addRedirectRule,
+    getRedirectRules,
+    removeRedirectRule,
+} from '../redirects';
+import type { RedirectRule } from '../types';
+import { STORAGE_KEYS } from '../types';
+import { STRINGS } from '../constants';
+import { capture, emitUserBlocked, emitUserSucceeded } from '../analytics';
+
+export function useRedirectRules() {
+    const [redirects, setRedirects] = useState<RedirectRule[]>([]);
+    const [from, setFrom] = useState('');
+    const [to, setTo] = useState('');
+    const [error, setError] = useState<string | null>(null);
+
+    const load = useCallback(async () => {
+        setRedirects(await getRedirectRules());
+    }, []);
+
+    useEffect(() => {
+        void load();
+    }, [load]);
+
+    useEffect(() => {
+        const listener = (
+            changes: Record<string, chrome.storage.StorageChange>
+        ) => {
+            if (STORAGE_KEYS.REDIRECT_RULES in changes) {
+                void load();
+            }
+        };
+        chrome.storage.onChanged.addListener(listener);
+        return () => chrome.storage.onChanged.removeListener(listener);
+    }, [load]);
+
+    const handleAdd = useCallback(async () => {
+        setError(null);
+        const trimmedFrom = from.trim();
+        const trimmedTo = to.trim();
+        if (!trimmedFrom || !trimmedTo) {
+            setError(STRINGS.ERR_REDIRECT_REQUIRED);
+            return;
+        }
+        try {
+            await addRedirectRule({ from: trimmedFrom, to: trimmedTo });
+            setFrom('');
+            setTo('');
+            capture('extension_redirect_rule_added');
+            emitUserSucceeded('redirect_rule_added', 'user_action');
+        } catch (e) {
+            // Chrome rejects patterns that aren't valid RE2 or substitutions
+            // without a matching regexFilter; surface its message verbatim.
+            const msg =
+                e instanceof Error ? e.message : STRINGS.ERR_REDIRECT_INVALID;
+            setError(msg);
+            capture('extension_error', { action: 'add_redirect', error: msg });
+            emitUserBlocked('redirect_rule_add_failed', 'user_action', {
+                error: msg,
+            });
+        }
+    }, [from, to]);
+
+    const handleRemove = useCallback(async (index: number) => {
+        setError(null);
+        try {
+            await removeRedirectRule(index);
+            capture('extension_redirect_rule_removed');
+            emitUserSucceeded('redirect_rule_removed', 'user_action');
+        } catch (e) {
+            const msg =
+                e instanceof Error ? e.message : STRINGS.ERR_REDIRECT_INVALID;
+            setError(msg);
+            capture('extension_error', {
+                action: 'remove_redirect',
+                error: msg,
+            });
+            emitUserBlocked('redirect_rule_remove_failed', 'user_action', {
+                error: msg,
+            });
+        }
+    }, []);
+
+    return {
+        redirects,
+        from,
+        to,
+        error,
+        setFrom,
+        setTo,
+        handleAdd,
+        handleRemove,
+    };
+}

--- a/src/joinSession.ts
+++ b/src/joinSession.ts
@@ -4,6 +4,7 @@
 import {
     buildDnrRule,
     getDynamicRules,
+    headerRuleIds,
     refreshIconIndicator,
     sessionInjectionPair,
     storageGet,
@@ -62,7 +63,7 @@ export async function joinMatchingSession(
         (stored[STORAGE_KEYS.SCOPE_PATTERNS] as string[] | undefined) ?? [];
     const existing = await getDynamicRules();
     await updateDynamicRules({
-        removeRuleIds: existing.map((r) => r.id),
+        removeRuleIds: headerRuleIds(existing),
         addRules: buildDnrRule(header, value, scope),
     });
     await storageSet({

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -18,8 +18,8 @@ import mirrordIconLight from './assets/mirrord-icon-light.svg';
 import { Moon, Settings, Share2, Sun, Check } from 'lucide-react';
 import { loadTheme, saveTheme, resolveDark } from './theme';
 import type { ThemePref } from './types';
-import { SessionsView, ManualSetup } from './components';
-import { useHeaderRules } from './hooks';
+import { SessionsView, ManualSetup, RedirectsSection } from './components';
+import { useHeaderRules, useRedirectRules } from './hooks';
 import { useMirrordUi } from './hooks/useMirrordUi';
 import {
     capture,
@@ -51,6 +51,7 @@ document.addEventListener('visibilitychange', () => {
 
 export function Popup() {
     const headerRules = useHeaderRules();
+    const redirectRules = useRedirectRules();
     const mirrordUi = useMirrordUi();
 
     // Sessions sharing a key are presented as one group, so count distinct keys
@@ -200,6 +201,7 @@ export function Popup() {
                         <ManualSetup headerRules={headerRules} />
                     </TabsContent>
                 </Tabs>
+                <RedirectsSection redirectRules={redirectRules} />
             </div>
         </TooltipProvider>
     );

--- a/src/redirects.ts
+++ b/src/redirects.ts
@@ -1,0 +1,48 @@
+// User-defined URL redirect rules, e.g. mapping an env-scoped host the app
+// links to (built from an injected header value) back onto a host that actually
+// resolves. Stored in chrome.storage.local as the source of truth and mirrored
+// into DNR redirect rules in their own id range (REDIRECT_RULE_ID_BASE+), so
+// header-injection flows never touch them.
+import {
+    buildRedirectDnrRules,
+    getDynamicRules,
+    isRedirectDnrRule,
+    storageGet,
+    storageSet,
+    updateDynamicRules,
+} from './util';
+import type { RedirectRule } from './types';
+import { STORAGE_KEYS } from './types';
+
+export async function getRedirectRules(): Promise<RedirectRule[]> {
+    const stored = await storageGet([STORAGE_KEYS.REDIRECT_RULES]);
+    const rules = stored[STORAGE_KEYS.REDIRECT_RULES] as
+        | RedirectRule[]
+        | undefined;
+    return rules ?? [];
+}
+
+// Persist `redirects` and swap the DNR redirect rules to match. Throws (from
+// updateDynamicRules) when a pattern is not valid RE2 or the substitution is
+// malformed — storage is only written after Chrome accepts the rules, so the
+// stored list never diverges from what's active.
+export async function setRedirectRules(
+    redirects: RedirectRule[]
+): Promise<void> {
+    const existing = await getDynamicRules();
+    await updateDynamicRules({
+        removeRuleIds: existing.filter(isRedirectDnrRule).map((r) => r.id),
+        addRules: buildRedirectDnrRules(redirects),
+    });
+    await storageSet({ [STORAGE_KEYS.REDIRECT_RULES]: redirects });
+}
+
+export async function addRedirectRule(rule: RedirectRule): Promise<void> {
+    const current = await getRedirectRules();
+    await setRedirectRules([...current, rule]);
+}
+
+export async function removeRedirectRule(index: number): Promise<void> {
+    const current = await getRedirectRules();
+    await setRedirectRules(current.filter((_, i) => i !== index));
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,9 +16,21 @@ export interface HeaderRule {
     scope: string;
 }
 
+// Redirect rules live in their own DNR id range so header flows (which wipe and
+// rebuild their rules wholesale) never clobber them, and vice versa.
+export const REDIRECT_RULE_ID_BASE = 1000;
+
+// A user-defined URL rewrite: requests matching the RE2 `from` pattern are
+// redirected to the `to` substitution (supports \1..\9 capture references).
+export interface RedirectRule {
+    from: string;
+    to: string;
+}
+
 export const STORAGE_KEYS = {
     DEFAULTS: 'defaults',
     OVERRIDE: 'override',
+    REDIRECT_RULES: 'redirect_rules',
     ANALYTICS_OPT_OUT: 'analytics_opt_out',
     MIRRORD_UI_BACKEND: 'mirrord_ui_backend',
     MIRRORD_UI_TOKEN: 'mirrord_ui_token',

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,8 +1,13 @@
 import RandExp from 'randexp';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
-import type { Config, HeaderRule, OperatorSessionSummary } from './types';
-import { ALL_RESOURCE_TYPES } from './types';
+import type {
+    Config,
+    HeaderRule,
+    OperatorSessionSummary,
+    RedirectRule,
+} from './types';
+import { ALL_RESOURCE_TYPES, REDIRECT_RULE_ID_BASE } from './types';
 import {
     STRINGS,
     METALBEAR_EXTENSION_URL,
@@ -96,6 +101,38 @@ export function buildDnrRule(
         },
         condition: {
             urlFilter,
+            resourceTypes: ALL_RESOURCE_TYPES,
+        },
+    }));
+}
+
+export function isRedirectDnrRule(
+    rule: chrome.declarativeNetRequest.Rule
+): boolean {
+    return rule.id >= REDIRECT_RULE_ID_BASE;
+}
+
+// Ids of the header-injection rules only. Header flows replace their rules
+// wholesale; passing this (instead of every existing id) to removeRuleIds keeps
+// redirect rules intact across save/join/leave/reset.
+export function headerRuleIds(
+    rules: chrome.declarativeNetRequest.Rule[]
+): number[] {
+    return rules.filter((r) => !isRedirectDnrRule(r)).map((r) => r.id);
+}
+
+export function buildRedirectDnrRules(
+    redirects: RedirectRule[]
+): chrome.declarativeNetRequest.Rule[] {
+    return redirects.map((redirect, idx) => ({
+        id: REDIRECT_RULE_ID_BASE + idx,
+        priority: 1,
+        action: {
+            type: chrome.declarativeNetRequest.RuleActionType.REDIRECT,
+            redirect: { regexSubstitution: redirect.to },
+        },
+        condition: {
+            regexFilter: redirect.from,
             resourceTypes: ALL_RESOURCE_TYPES,
         },
     }));


### PR DESCRIPTION
> [!NOTE]
> Opened by Han's support bot from a support-thread investigation. Review before adopting; tracked in PRO-218 (Triage) — adopt if low-hanging.

Adds user-defined URL redirect rules: requests matching an RE2 pattern are rewritten to a substitution (`\1..\9` capture refs) before they are sent, via DNR `redirect` rules.

Why: apps that build per-env hostnames from the injected header can redirect the browser to hosts that don't exist when no env is deployed for the mirrord session key. A redirect rule maps those URLs back onto a real host, e.g. `^https://app-[^.]*\.example\.com/(.*)` → `https://app-master.example.com/\1`, while the injected header keeps routing traffic to the user's session.

- Redirect rules get their own DNR id range (1000+); header save/join/leave/reset flows now wipe only header-rule ids, so the two rule sets never clobber each other.
- New "URL redirects" popup section (shown on both tabs); list stored in `chrome.storage.local`, written only after Chrome accepts the rules.
- 6 new unit tests; full suite (205), typecheck, lint, prettier, and vite build green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)